### PR TITLE
Implement Docker volume API backed by Kubernetes PVCs

### DIFF
--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/chainguard-dev/clog"
 	"github.com/google/uuid"
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
 	"github.com/moby/moby/api/types/system"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -89,18 +90,62 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 		corev1.ResourceMemory: resource.MustParse(fmt.Sprintf("%d", mem)),
 	}
 
+	// Parse volume mounts from the request.
+	var podVolumes []corev1.Volume
+	var containerMounts []corev1.VolumeMount
+	coveredPaths := map[string]bool{}
+
+	if req.HostConfig != nil {
+		// Parse Binds: "source:dest[:options]"
+		if len(req.HostConfig.Binds) > 0 {
+			vols, mnts, err := parseBinds(req.HostConfig.Binds)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+				return
+			}
+			podVolumes = append(podVolumes, vols...)
+			containerMounts = append(containerMounts, mnts...)
+			for _, m := range mnts {
+				coveredPaths[m.MountPath] = true
+			}
+		}
+
+		// Parse Mounts (structured mount API).
+		if len(req.HostConfig.Mounts) > 0 {
+			vols, vmounts, err := parseDockerMounts(req.HostConfig.Mounts)
+			if err != nil {
+				writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+				return
+			}
+			podVolumes = append(podVolumes, vols...)
+			containerMounts = append(containerMounts, vmounts...)
+			for _, m := range vmounts {
+				coveredPaths[m.MountPath] = true
+			}
+		}
+	}
+
+	// Parse Config.Volumes (anonymous volumes).
+	if len(req.Config.Volumes) > 0 {
+		vols, mnts := parseAnonymousVolumes(req.Config.Volumes, coveredPaths)
+		podVolumes = append(podVolumes, vols...)
+		containerMounts = append(containerMounts, mnts...)
+	}
+
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
+			Volumes:       podVolumes,
 			Containers: []corev1.Container{{
-				Name:       "main",
-				Image:      req.Config.Image,
-				WorkingDir: req.Config.WorkingDir,
-				Command:    req.Config.Entrypoint,
-				Args:       req.Config.Cmd,
-				Env:        env,
-				Resources:  corev1.ResourceRequirements{Requests: res},
+				Name:         "main",
+				Image:        req.Config.Image,
+				WorkingDir:   req.Config.WorkingDir,
+				Command:      req.Config.Entrypoint,
+				Args:         req.Config.Cmd,
+				Env:          env,
+				Resources:    corev1.ResourceRequirements{Requests: res},
+				VolumeMounts: containerMounts,
 			}},
 		},
 	}
@@ -202,11 +247,38 @@ func (s *Server) containerInspect(w http.ResponseWriter, r *http.Request) {
 		env = append(env, fmt.Sprintf("%s=%s", e.Name, e.Value))
 	}
 
+	// Build Mounts from pod volumes.
+	var mounts []container.MountPoint
+	for _, vm := range pod.Spec.Containers[0].VolumeMounts {
+		mp := container.MountPoint{
+			Destination: vm.MountPath,
+			RW:          !vm.ReadOnly,
+		}
+		// Find the corresponding pod volume to determine type/source.
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == vm.Name {
+				if v.PersistentVolumeClaim != nil {
+					mp.Type = mount.TypeVolume
+					mp.Name = v.PersistentVolumeClaim.ClaimName
+					mp.Source = v.PersistentVolumeClaim.ClaimName
+					mp.Driver = "local"
+				} else if v.EmptyDir != nil {
+					mp.Type = mount.TypeVolume
+					mp.Name = v.Name
+					mp.Source = ""
+				}
+				break
+			}
+		}
+		mounts = append(mounts, mp)
+	}
+
 	writeJSON(w, http.StatusOK, container.InspectResponse{
-		ID:    pod.Name,
-		Image: pod.Spec.Containers[0].Image,
-		Name:  "/" + pod.Name,
-		State: podToState(pod),
+		ID:     pod.Name,
+		Image:  pod.Spec.Containers[0].Image,
+		Name:   "/" + pod.Name,
+		State:  podToState(pod),
+		Mounts: mounts,
 		Config: &container.Config{
 			Env:        env,
 			Entrypoint: pod.Spec.Containers[0].Command,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -66,6 +66,13 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /exec/{id}/json", s.execInspect)
 	mux.HandleFunc("POST /exec/{id}/resize", s.execResize)
 
+	// Volumes (order matters: /create and /prune before /{name} wildcard)
+	mux.HandleFunc("GET /volumes", s.volumeList)
+	mux.HandleFunc("POST /volumes/create", s.volumeCreate)
+	mux.HandleFunc("POST /volumes/prune", s.volumePrune)
+	mux.HandleFunc("GET /volumes/{name}", s.volumeInspect)
+	mux.HandleFunc("DELETE /volumes/{name}", s.volumeDelete)
+
 	// The Docker client may prefix requests with /v1.45/ etc.
 	return s.middleware(stripVersionPrefix(mux))
 }

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -1,0 +1,309 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/volume"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	labelApp       = "app"
+	labelAppValue  = "badidea"
+	defaultStorage = "1Gi"
+	volumeNS       = "default"
+)
+
+var badideaLabels = map[string]string{labelApp: labelAppValue}
+
+func pvcToVolume(pvc *corev1.PersistentVolumeClaim) volume.Volume {
+	created := pvc.CreationTimestamp.Format(time.RFC3339)
+	return volume.Volume{
+		Name:       pvc.Name,
+		Driver:     "local",
+		Mountpoint: "/var/lib/badidea/volumes/" + pvc.Name,
+		CreatedAt:  created,
+		Status:     map[string]any{"phase": string(pvc.Status.Phase)},
+		Labels:     pvc.Labels,
+		Scope:      "local",
+		Options:    map[string]string{},
+	}
+}
+
+// --- Volume endpoints ---
+
+func (s *Server) volumeList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clog.FromContext(ctx).Info("listing volumes")
+
+	pvcs, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", labelApp, labelAppValue),
+	})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	volumes := make([]volume.Volume, 0, len(pvcs.Items))
+	for i := range pvcs.Items {
+		volumes = append(volumes, pvcToVolume(&pvcs.Items[i]))
+	}
+
+	writeJSON(w, http.StatusOK, volume.ListResponse{
+		Volumes:  volumes,
+		Warnings: []string{},
+	})
+}
+
+func (s *Server) volumeCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	log := clog.FromContext(ctx)
+
+	var req volume.CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+		return
+	}
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"volume name is required"})
+		return
+	}
+	log.With("name", req.Name).Info("creating volume")
+
+	labels := make(map[string]string)
+	for k, v := range badideaLabels {
+		labels[k] = v
+	}
+	for k, v := range req.Labels {
+		labels[k] = v
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: volumeNS,
+			Labels:    labels,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(defaultStorage),
+				},
+			},
+		},
+	}
+
+	created, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Create(ctx, pvc, metav1.CreateOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, pvcToVolume(created))
+}
+
+func (s *Server) volumeInspect(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	clog.FromContext(ctx).With("name", name).Info("inspecting volume")
+
+	pvc, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, pvcToVolume(pvc))
+}
+
+func (s *Server) volumeDelete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	clog.FromContext(ctx).With("name", name).Info("deleting volume")
+
+	err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) volumePrune(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clog.FromContext(ctx).Info("pruning volumes")
+
+	pvcs, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", labelApp, labelAppValue),
+	})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	pods, err := s.clientset.CoreV1().Pods(volumeNS).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	inUse := map[string]bool{}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
+			for _, vol := range pod.Spec.Volumes {
+				if vol.PersistentVolumeClaim != nil {
+					inUse[vol.PersistentVolumeClaim.ClaimName] = true
+				}
+			}
+		}
+	}
+
+	var deleted []string
+	var reclaimedBytes int64
+	for _, pvc := range pvcs.Items {
+		if inUse[pvc.Name] {
+			continue
+		}
+		if err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Delete(ctx, pvc.Name, metav1.DeleteOptions{}); err == nil {
+			deleted = append(deleted, pvc.Name)
+			if q, ok := pvc.Spec.Resources.Requests[corev1.ResourceStorage]; ok {
+				reclaimedBytes += q.Value()
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, volume.PruneReport{
+		VolumesDeleted:  deleted,
+		SpaceReclaimed: uint64(reclaimedBytes),
+	})
+}
+
+// parseBinds parses HostConfig.Binds entries and returns pod volumes and container mounts.
+// Format: "source:dest[:options]"
+// If source starts with "/", it's a bind mount (unsupported).
+// Otherwise, source is a named volume.
+func parseBinds(binds []string) ([]corev1.Volume, []corev1.VolumeMount, error) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+
+	for _, bind := range binds {
+		parts := strings.SplitN(bind, ":", 3)
+		if len(parts) < 2 {
+			return nil, nil, fmt.Errorf("invalid bind mount spec: %s", bind)
+		}
+		source := parts[0]
+		dest := parts[1]
+
+		if strings.HasPrefix(source, "/") {
+			return nil, nil, fmt.Errorf("bind mounts are not supported; use named volumes instead")
+		}
+
+		readOnly := false
+		if len(parts) == 3 && strings.Contains(parts[2], "ro") {
+			readOnly = true
+		}
+
+		volName := "vol-" + source
+		volumes = append(volumes, corev1.Volume{
+			Name: volName,
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+					ClaimName: source,
+					ReadOnly:  readOnly,
+				},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      volName,
+			MountPath: dest,
+			ReadOnly:  readOnly,
+		})
+	}
+
+	return volumes, mounts, nil
+}
+
+// parseDockerMounts parses HostConfig.Mounts entries.
+func parseDockerMounts(mnts []mount.Mount) ([]corev1.Volume, []corev1.VolumeMount, error) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+
+	for i, m := range mnts {
+		switch m.Type {
+		case mount.TypeVolume:
+			if m.Source == "" {
+				return nil, nil, fmt.Errorf("mount[%d]: volume source is required", i)
+			}
+			volName := "vol-" + m.Source
+			volumes = append(volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: m.Source,
+						ReadOnly:  m.ReadOnly,
+					},
+				},
+			})
+			mounts = append(mounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: m.Target,
+				ReadOnly:  m.ReadOnly,
+			})
+		case mount.TypeTmpfs:
+			volName := fmt.Sprintf("tmpfs-%d", i)
+			volumes = append(volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{
+						Medium: corev1.StorageMediumMemory,
+					},
+				},
+			})
+			mounts = append(mounts, corev1.VolumeMount{
+				Name:      volName,
+				MountPath: m.Target,
+			})
+		case mount.TypeBind:
+			return nil, nil, fmt.Errorf("bind mounts are not supported; use named volumes instead")
+		default:
+			return nil, nil, fmt.Errorf("mount[%d]: unsupported mount type %q", i, m.Type)
+		}
+	}
+
+	return volumes, mounts, nil
+}
+
+// parseAnonymousVolumes creates emptyDir volumes for Config.Volumes entries
+// that aren't already covered by Binds or Mounts.
+func parseAnonymousVolumes(configVolumes map[string]struct{}, coveredPaths map[string]bool) ([]corev1.Volume, []corev1.VolumeMount) {
+	var volumes []corev1.Volume
+	var mounts []corev1.VolumeMount
+	idx := 0
+	for path := range configVolumes {
+		if coveredPaths[path] {
+			continue
+		}
+		volName := fmt.Sprintf("anon-%d", idx)
+		idx++
+		volumes = append(volumes, corev1.Volume{
+			Name: volName,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+		mounts = append(mounts, corev1.VolumeMount{
+			Name:      volName,
+			MountPath: path,
+		})
+	}
+	return volumes, mounts
+}

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -1,0 +1,613 @@
+package server
+
+import (
+	"io"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/volume"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+// newTestServerWithPVCs creates a test server pre-loaded with pods and PVCs.
+func newTestServerWithPVCs(pods []corev1.Pod, pvcs []corev1.PersistentVolumeClaim) *httptest.Server {
+	clientset := fake.NewSimpleClientset()
+	for i := range pods {
+		clientset.Tracker().Add(&pods[i])
+	}
+	for i := range pvcs {
+		clientset.Tracker().Add(&pvcs[i])
+	}
+	s := New(clientset, rest.Config{})
+	return httptest.NewServer(s.Handler())
+}
+
+func TestVolumeCreateAndInspect(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	// Create
+	resp := request(t, ts, "POST", "/volumes/create",
+		`{"Name": "mydata", "Labels": {"env": "test"}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+	v := decodeJSON[volume.Volume](t, resp)
+	if v.Name != "mydata" {
+		t.Errorf("name: got %q, want %q", v.Name, "mydata")
+	}
+	if v.Driver != "local" {
+		t.Errorf("driver: got %q, want %q", v.Driver, "local")
+	}
+	if v.Labels["env"] != "test" {
+		t.Errorf("labels: got %v, want env=test", v.Labels)
+	}
+	if v.Labels[labelApp] != labelAppValue {
+		t.Errorf("labels: missing %s=%s", labelApp, labelAppValue)
+	}
+
+	// Inspect
+	resp = request(t, ts, "GET", "/volumes/mydata", "")
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect: got %d, want 200: %s", resp.StatusCode, body)
+	}
+	v = decodeJSON[volume.Volume](t, resp)
+	if v.Name != "mydata" {
+		t.Errorf("inspect name: got %q, want %q", v.Name, "mydata")
+	}
+}
+
+func TestVolumeCreateMissingName(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/volumes/create", `{}`)
+	resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestVolumeCreateDuplicate(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/volumes/create", `{"Name": "dup"}`)
+	resp.Body.Close()
+	if resp.StatusCode != 201 {
+		t.Fatalf("first create: got %d", resp.StatusCode)
+	}
+
+	resp = request(t, ts, "POST", "/volumes/create", `{"Name": "dup"}`)
+	resp.Body.Close()
+	if resp.StatusCode != 409 {
+		t.Errorf("duplicate create: got %d, want 409", resp.StatusCode)
+	}
+}
+
+func TestVolumeInspectNotFound(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/volumes/nope", "")
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestVolumeDelete(t *testing.T) {
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "todelete",
+			Namespace: "default",
+			Labels:    map[string]string{labelApp: labelAppValue},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse("1Gi"),
+				},
+			},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, []corev1.PersistentVolumeClaim{pvc})
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/volumes/todelete", "")
+	resp.Body.Close()
+	if resp.StatusCode != 204 {
+		t.Errorf("delete: got %d, want 204", resp.StatusCode)
+	}
+
+	// Verify gone
+	resp = request(t, ts, "GET", "/volumes/todelete", "")
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("inspect after delete: got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestVolumeDeleteNotFound(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/volumes/nope", "")
+	resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestVolumeList(t *testing.T) {
+	pvcs := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-a",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vol-b",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, pvcs)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/volumes", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("list: got %d, want 200", resp.StatusCode)
+	}
+	lr := decodeJSON[volume.ListResponse](t, resp)
+	if len(lr.Volumes) != 2 {
+		t.Errorf("got %d volumes, want 2", len(lr.Volumes))
+	}
+}
+
+func TestVolumeListEmpty(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/volumes", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("got %d, want 200", resp.StatusCode)
+	}
+	lr := decodeJSON[volume.ListResponse](t, resp)
+	if len(lr.Volumes) != 0 {
+		t.Errorf("got %d volumes, want 0", len(lr.Volumes))
+	}
+}
+
+func TestVolumePrune(t *testing.T) {
+	pvcs := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unused-vol",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "used-vol",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		},
+	}
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{Name: "main", Image: "alpine"}},
+				Volumes: []corev1.Volume{
+					{
+						Name: "vol-used-vol",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "used-vol",
+							},
+						},
+					},
+				},
+			},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	}
+	ts := newTestServerWithPVCs(pods, pvcs)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/volumes/prune", "")
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("prune: got %d, want 200: %s", resp.StatusCode, body)
+	}
+	pr := decodeJSON[volume.PruneReport](t, resp)
+	if len(pr.VolumesDeleted) != 1 {
+		t.Errorf("got %d deleted, want 1: %v", len(pr.VolumesDeleted), pr.VolumesDeleted)
+	}
+	if len(pr.VolumesDeleted) > 0 && pr.VolumesDeleted[0] != "unused-vol" {
+		t.Errorf("deleted %q, want %q", pr.VolumesDeleted[0], "unused-vol")
+	}
+
+	// used-vol should still exist
+	resp = request(t, ts, "GET", "/volumes/used-vol", "")
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("used-vol should still exist, got %d", resp.StatusCode)
+	}
+}
+
+func TestContainerCreateWithBinds(t *testing.T) {
+	// Pre-create a PVC for the named volume.
+	pvcs := []corev1.PersistentVolumeClaim{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mydata",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, pvcs)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=vol-test",
+		`{"Image": "alpine", "HostConfig": {"Binds": ["mydata:/data"]}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+	cr := decodeJSON[container.CreateResponse](t, resp)
+	if cr.ID != "vol-test" {
+		t.Errorf("got ID %q, want %q", cr.ID, "vol-test")
+	}
+
+	// Inspect and verify mounts
+	resp = request(t, ts, "GET", "/containers/vol-test/json", "")
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect: got %d, want 200: %s", resp.StatusCode, body)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(ir.Mounts))
+	}
+	m := ir.Mounts[0]
+	if m.Type != mount.TypeVolume {
+		t.Errorf("mount type: got %q, want %q", m.Type, mount.TypeVolume)
+	}
+	if m.Name != "mydata" {
+		t.Errorf("mount name: got %q, want %q", m.Name, "mydata")
+	}
+	if m.Destination != "/data" {
+		t.Errorf("mount dest: got %q, want %q", m.Destination, "/data")
+	}
+	if !m.RW {
+		t.Error("mount should be read-write")
+	}
+}
+
+func TestContainerCreateWithBindsReadOnly(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=ro-test",
+		`{"Image": "alpine", "HostConfig": {"Binds": ["mydata:/data:ro"]}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+
+	resp = request(t, ts, "GET", "/containers/ro-test/json", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(ir.Mounts))
+	}
+	if ir.Mounts[0].RW {
+		t.Error("mount should be read-only")
+	}
+}
+
+func TestContainerCreateWithBindMount(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	// Bind mounts (absolute path) should be rejected.
+	resp := request(t, ts, "POST", "/containers/create?name=bind-test",
+		`{"Image": "alpine", "HostConfig": {"Binds": ["/host/path:/data"]}}`)
+	resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("bind mount: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestContainerCreateWithDockerMounts(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=mounts-test",
+		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "volume", "Source": "myvol", "Target": "/app/data"}]}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+
+	resp = request(t, ts, "GET", "/containers/mounts-test/json", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(ir.Mounts))
+	}
+	if ir.Mounts[0].Name != "myvol" {
+		t.Errorf("mount name: got %q, want %q", ir.Mounts[0].Name, "myvol")
+	}
+	if ir.Mounts[0].Destination != "/app/data" {
+		t.Errorf("mount dest: got %q, want %q", ir.Mounts[0].Destination, "/app/data")
+	}
+}
+
+func TestContainerCreateWithTmpfsMount(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=tmpfs-test",
+		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "tmpfs", "Target": "/tmp/scratch"}]}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+
+	resp = request(t, ts, "GET", "/containers/tmpfs-test/json", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1", len(ir.Mounts))
+	}
+	if ir.Mounts[0].Type != mount.TypeVolume {
+		t.Errorf("mount type: got %q, want %q", ir.Mounts[0].Type, mount.TypeVolume)
+	}
+}
+
+func TestContainerCreateWithBindMountType(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=bind-type-test",
+		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "bind", "Source": "/host", "Target": "/data"}]}}`)
+	resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("bind mount type: got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestContainerCreateWithAnonymousVolumes(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=anon-test",
+		`{"Image": "alpine", "Volumes": {"/data": {}, "/cache": {}}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+
+	resp = request(t, ts, "GET", "/containers/anon-test/json", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 2 {
+		t.Fatalf("got %d mounts, want 2", len(ir.Mounts))
+	}
+}
+
+func TestContainerCreateAnonymousVolumeSkipsCovered(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	// /data is covered by a Bind, so Config.Volumes should not create another mount for it.
+	resp := request(t, ts, "POST", "/containers/create?name=covered-test",
+		`{"Image": "alpine", "Volumes": {"/data": {}}, "HostConfig": {"Binds": ["myvol:/data"]}}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+	}
+
+	resp = request(t, ts, "GET", "/containers/covered-test/json", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if len(ir.Mounts) != 1 {
+		t.Fatalf("got %d mounts, want 1 (anonymous should be skipped)", len(ir.Mounts))
+	}
+	if ir.Mounts[0].Name != "myvol" {
+		t.Errorf("mount name: got %q, want %q", ir.Mounts[0].Name, "myvol")
+	}
+}
+
+// --- Unit tests for parse functions ---
+
+func TestParseBinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		binds   []string
+		wantErr string
+		wantN   int
+	}{
+		{"named volume", []string{"foo:/data"}, "", 1},
+		{"read-only", []string{"foo:/data:ro"}, "", 1},
+		{"bind mount rejected", []string{"/host:/data"}, "bind mounts are not supported", 0},
+		{"invalid spec", []string{"nocolon"}, "invalid bind mount spec", 0},
+		{"multiple", []string{"a:/x", "b:/y"}, "", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vols, mounts, err := parseBinds(tt.binds)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("got err %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(vols) != tt.wantN || len(mounts) != tt.wantN {
+				t.Errorf("got %d vols, %d mounts, want %d each", len(vols), len(mounts), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestParseDockerMounts(t *testing.T) {
+	tests := []struct {
+		name    string
+		mounts  []mount.Mount
+		wantErr string
+		wantN   int
+	}{
+		{
+			"volume mount",
+			[]mount.Mount{{Type: mount.TypeVolume, Source: "myvol", Target: "/data"}},
+			"", 1,
+		},
+		{
+			"tmpfs mount",
+			[]mount.Mount{{Type: mount.TypeTmpfs, Target: "/tmp"}},
+			"", 1,
+		},
+		{
+			"bind rejected",
+			[]mount.Mount{{Type: mount.TypeBind, Source: "/host", Target: "/data"}},
+			"bind mounts are not supported", 0,
+		},
+		{
+			"volume missing source",
+			[]mount.Mount{{Type: mount.TypeVolume, Target: "/data"}},
+			"volume source is required", 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vols, mounts, err := parseDockerMounts(tt.mounts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("got err %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(vols) != tt.wantN || len(mounts) != tt.wantN {
+				t.Errorf("got %d vols, %d mounts, want %d each", len(vols), len(mounts), tt.wantN)
+			}
+		})
+	}
+}
+
+func TestParseAnonymousVolumes(t *testing.T) {
+	configVolumes := map[string]struct{}{
+		"/data":  {},
+		"/cache": {},
+		"/logs":  {},
+	}
+	covered := map[string]bool{"/data": true}
+
+	vols, mounts := parseAnonymousVolumes(configVolumes, covered)
+	if len(vols) != 2 || len(mounts) != 2 {
+		t.Errorf("got %d vols, %d mounts, want 2 each", len(vols), len(mounts))
+	}
+	for _, m := range mounts {
+		if m.MountPath == "/data" {
+			t.Error("should not have created mount for covered path /data")
+		}
+	}
+}
+
+func TestVolumeCreateAndList(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	// Create two volumes
+	for _, name := range []string{"vol1", "vol2"} {
+		resp := request(t, ts, "POST", "/volumes/create", `{"Name": "`+name+`"}`)
+		resp.Body.Close()
+		if resp.StatusCode != 201 {
+			t.Fatalf("create %s: got %d", name, resp.StatusCode)
+		}
+	}
+
+	resp := request(t, ts, "GET", "/volumes", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("list: got %d", resp.StatusCode)
+	}
+	lr := decodeJSON[volume.ListResponse](t, resp)
+	if len(lr.Volumes) != 2 {
+		t.Errorf("got %d volumes, want 2", len(lr.Volumes))
+	}
+}
+
+func TestVolumeVersionPrefix(t *testing.T) {
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/v1.45/volumes/create", `{"Name": "prefixed"}`)
+	if resp.StatusCode != 201 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create with version prefix: got %d, want 201: %s", resp.StatusCode, body)
+	}
+	v := decodeJSON[volume.Volume](t, resp)
+	if v.Name != "prefixed" {
+		t.Errorf("name: got %q, want %q", v.Name, "prefixed")
+	}
+}

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -36,9 +37,9 @@ func TestVolumeCreateAndInspect(t *testing.T) {
 	// Create
 	resp := request(t, ts, "POST", "/volumes/create",
 		`{"Name": "mydata", "Labels": {"env": "test"}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 	v := decodeJSON[volume.Volume](t, resp)
 	if v.Name != "mydata" {
@@ -56,9 +57,9 @@ func TestVolumeCreateAndInspect(t *testing.T) {
 
 	// Inspect
 	resp = request(t, ts, "GET", "/volumes/mydata", "")
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("inspect: got %d, want 200: %s", resp.StatusCode, body)
+		t.Fatalf("inspect: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
 	}
 	v = decodeJSON[volume.Volume](t, resp)
 	if v.Name != "mydata" {
@@ -72,8 +73,8 @@ func TestVolumeCreateMissingName(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/volumes/create", `{}`)
 	resp.Body.Close()
-	if resp.StatusCode != 400 {
-		t.Errorf("got %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 
@@ -83,14 +84,14 @@ func TestVolumeCreateDuplicate(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/volumes/create", `{"Name": "dup"}`)
 	resp.Body.Close()
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		t.Fatalf("first create: got %d", resp.StatusCode)
 	}
 
 	resp = request(t, ts, "POST", "/volumes/create", `{"Name": "dup"}`)
 	resp.Body.Close()
-	if resp.StatusCode != 409 {
-		t.Errorf("duplicate create: got %d, want 409", resp.StatusCode)
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("duplicate create: got %d, want %d", resp.StatusCode, http.StatusConflict)
 	}
 }
 
@@ -100,8 +101,8 @@ func TestVolumeInspectNotFound(t *testing.T) {
 
 	resp := request(t, ts, "GET", "/volumes/nope", "")
 	resp.Body.Close()
-	if resp.StatusCode != 404 {
-		t.Errorf("got %d, want 404", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 
@@ -126,15 +127,15 @@ func TestVolumeDelete(t *testing.T) {
 
 	resp := request(t, ts, "DELETE", "/volumes/todelete", "")
 	resp.Body.Close()
-	if resp.StatusCode != 204 {
-		t.Errorf("delete: got %d, want 204", resp.StatusCode)
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete: got %d, want %d", resp.StatusCode, http.StatusNoContent)
 	}
 
 	// Verify gone
 	resp = request(t, ts, "GET", "/volumes/todelete", "")
 	resp.Body.Close()
-	if resp.StatusCode != 404 {
-		t.Errorf("inspect after delete: got %d, want 404", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("inspect after delete: got %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 
@@ -144,8 +145,8 @@ func TestVolumeDeleteNotFound(t *testing.T) {
 
 	resp := request(t, ts, "DELETE", "/volumes/nope", "")
 	resp.Body.Close()
-	if resp.StatusCode != 404 {
-		t.Errorf("got %d, want 404", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 
@@ -176,8 +177,8 @@ func TestVolumeList(t *testing.T) {
 	defer ts.Close()
 
 	resp := request(t, ts, "GET", "/volumes", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("list: got %d, want 200", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	lr := decodeJSON[volume.ListResponse](t, resp)
 	if len(lr.Volumes) != 2 {
@@ -190,8 +191,8 @@ func TestVolumeListEmpty(t *testing.T) {
 	defer ts.Close()
 
 	resp := request(t, ts, "GET", "/volumes", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("got %d, want 200", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	lr := decodeJSON[volume.ListResponse](t, resp)
 	if len(lr.Volumes) != 0 {
@@ -255,9 +256,9 @@ func TestVolumePrune(t *testing.T) {
 	defer ts.Close()
 
 	resp := request(t, ts, "POST", "/volumes/prune", "")
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("prune: got %d, want 200: %s", resp.StatusCode, body)
+		t.Fatalf("prune: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
 	}
 	pr := decodeJSON[volume.PruneReport](t, resp)
 	if len(pr.VolumesDeleted) != 1 {
@@ -270,7 +271,7 @@ func TestVolumePrune(t *testing.T) {
 	// used-vol should still exist
 	resp = request(t, ts, "GET", "/volumes/used-vol", "")
 	resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		t.Errorf("used-vol should still exist, got %d", resp.StatusCode)
 	}
 }
@@ -294,9 +295,9 @@ func TestContainerCreateWithBinds(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/containers/create?name=vol-test",
 		`{"Image": "alpine", "HostConfig": {"Binds": ["mydata:/data"]}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 	cr := decodeJSON[container.CreateResponse](t, resp)
 	if cr.ID != "vol-test" {
@@ -305,9 +306,9 @@ func TestContainerCreateWithBinds(t *testing.T) {
 
 	// Inspect and verify mounts
 	resp = request(t, ts, "GET", "/containers/vol-test/json", "")
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("inspect: got %d, want 200: %s", resp.StatusCode, body)
+		t.Fatalf("inspect: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 1 {
@@ -334,14 +335,14 @@ func TestContainerCreateWithBindsReadOnly(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/containers/create?name=ro-test",
 		`{"Image": "alpine", "HostConfig": {"Binds": ["mydata:/data:ro"]}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 
 	resp = request(t, ts, "GET", "/containers/ro-test/json", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("inspect: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 1 {
@@ -360,8 +361,8 @@ func TestContainerCreateWithBindMount(t *testing.T) {
 	resp := request(t, ts, "POST", "/containers/create?name=bind-test",
 		`{"Image": "alpine", "HostConfig": {"Binds": ["/host/path:/data"]}}`)
 	resp.Body.Close()
-	if resp.StatusCode != 400 {
-		t.Errorf("bind mount: got %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bind mount: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 
@@ -371,14 +372,14 @@ func TestContainerCreateWithDockerMounts(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/containers/create?name=mounts-test",
 		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "volume", "Source": "myvol", "Target": "/app/data"}]}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 
 	resp = request(t, ts, "GET", "/containers/mounts-test/json", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("inspect: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 1 {
@@ -398,14 +399,14 @@ func TestContainerCreateWithTmpfsMount(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/containers/create?name=tmpfs-test",
 		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "tmpfs", "Target": "/tmp/scratch"}]}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 
 	resp = request(t, ts, "GET", "/containers/tmpfs-test/json", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("inspect: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 1 {
@@ -423,8 +424,8 @@ func TestContainerCreateWithBindMountType(t *testing.T) {
 	resp := request(t, ts, "POST", "/containers/create?name=bind-type-test",
 		`{"Image": "alpine", "HostConfig": {"Mounts": [{"Type": "bind", "Source": "/host", "Target": "/data"}]}}`)
 	resp.Body.Close()
-	if resp.StatusCode != 400 {
-		t.Errorf("bind mount type: got %d, want 400", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("bind mount type: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 
@@ -434,14 +435,14 @@ func TestContainerCreateWithAnonymousVolumes(t *testing.T) {
 
 	resp := request(t, ts, "POST", "/containers/create?name=anon-test",
 		`{"Image": "alpine", "Volumes": {"/data": {}, "/cache": {}}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 
 	resp = request(t, ts, "GET", "/containers/anon-test/json", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("inspect: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 2 {
@@ -456,14 +457,14 @@ func TestContainerCreateAnonymousVolumeSkipsCovered(t *testing.T) {
 	// /data is covered by a Bind, so Config.Volumes should not create another mount for it.
 	resp := request(t, ts, "POST", "/containers/create?name=covered-test",
 		`{"Image": "alpine", "Volumes": {"/data": {}}, "HostConfig": {"Binds": ["myvol:/data"]}}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 
 	resp = request(t, ts, "GET", "/containers/covered-test/json", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("inspect: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	ir := decodeJSON[container.InspectResponse](t, resp)
 	if len(ir.Mounts) != 1 {
@@ -582,14 +583,14 @@ func TestVolumeCreateAndList(t *testing.T) {
 	for _, name := range []string{"vol1", "vol2"} {
 		resp := request(t, ts, "POST", "/volumes/create", `{"Name": "`+name+`"}`)
 		resp.Body.Close()
-		if resp.StatusCode != 201 {
-			t.Fatalf("create %s: got %d", name, resp.StatusCode)
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: got %d, want %d", name, resp.StatusCode, http.StatusCreated)
 		}
 	}
 
 	resp := request(t, ts, "GET", "/volumes", "")
-	if resp.StatusCode != 200 {
-		t.Fatalf("list: got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 	lr := decodeJSON[volume.ListResponse](t, resp)
 	if len(lr.Volumes) != 2 {
@@ -602,9 +603,9 @@ func TestVolumeVersionPrefix(t *testing.T) {
 	defer ts.Close()
 
 	resp := request(t, ts, "POST", "/v1.45/volumes/create", `{"Name": "prefixed"}`)
-	if resp.StatusCode != 201 {
+	if resp.StatusCode != http.StatusCreated {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("create with version prefix: got %d, want 201: %s", resp.StatusCode, body)
+		t.Fatalf("create with version prefix: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
 	}
 	v := decodeJSON[volume.Volume](t, resp)
 	if v.Name != "prefixed" {

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -345,6 +345,151 @@ func TestKillContainer(t *testing.T) {
 	t.Errorf("container %s still running 30s after kill", name)
 }
 
+// --- Volume tests ---
+
+func TestVolumeCreateInspectRm(t *testing.T) {
+	name := "test-vol-" + randomSuffix()
+
+	// Create
+	out := dockerRun(t, "volume", "create", name)
+	if !strings.Contains(out, name) {
+		t.Errorf("expected volume name %q in create output, got: %s", name, out)
+	}
+
+	// Inspect
+	out = dockerRun(t, "volume", "inspect", name)
+	var volumes []map[string]any
+	if err := json.Unmarshal([]byte(out), &volumes); err != nil {
+		t.Fatalf("failed to parse volume inspect output: %v", err)
+	}
+	if len(volumes) == 0 {
+		t.Fatal("expected at least one volume in inspect output")
+	}
+	if got, _ := volumes[0]["Name"].(string); got != name {
+		t.Errorf("expected volume name %q, got %q", name, got)
+	}
+
+	// Remove
+	dockerRun(t, "volume", "rm", name)
+
+	// Verify gone
+	cmd := dockerCmd("volume", "inspect", name)
+	if err := cmd.Run(); err == nil {
+		t.Error("expected volume inspect to fail after rm, but it succeeded")
+	}
+}
+
+func TestVolumeList(t *testing.T) {
+	name := "test-volls-" + randomSuffix()
+
+	dockerRun(t, "volume", "create", name)
+	defer dockerCmd("volume", "rm", name).Run()
+
+	out := dockerRun(t, "volume", "ls")
+	if !strings.Contains(out, name) {
+		t.Errorf("expected %q in volume ls output, got: %s", name, out)
+	}
+}
+
+func TestVolumePrune(t *testing.T) {
+	name := "test-volpr-" + randomSuffix()
+
+	dockerRun(t, "volume", "create", name)
+
+	// Prune unused volumes.
+	out := dockerRun(t, "volume", "prune", "-f")
+	t.Logf("volume prune output: %s", out)
+
+	// The volume should be gone.
+	cmd := dockerCmd("volume", "inspect", name)
+	if err := cmd.Run(); err == nil {
+		t.Error("expected volume inspect to fail after prune, but it succeeded")
+	}
+}
+
+func TestRunWithNamedVolume(t *testing.T) {
+	volName := "test-runvol-" + randomSuffix()
+	name := "test-volrun-" + randomSuffix()
+
+	// Create a volume.
+	dockerRun(t, "volume", "create", volName)
+	defer dockerCmd("volume", "rm", volName).Run()
+
+	// Run a container that writes to the volume.
+	dockerRun(t, "run", "--name", name, "-v", volName+":/data",
+		"busybox", "sh", "-c", "echo hello-volume > /data/test.txt")
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Run another container that reads from the same volume.
+	name2 := "test-volread-" + randomSuffix()
+	out := dockerRun(t, "run", "--name", name2, "-v", volName+":/data",
+		"busybox", "cat", "/data/test.txt")
+	defer dockerCmd("rm", "-f", name2).Run()
+
+	if !strings.Contains(out, "hello-volume") {
+		t.Errorf("expected 'hello-volume' in output, got: %s", out)
+	}
+}
+
+func TestRunWithTmpfs(t *testing.T) {
+	name := "test-tmpfs-" + randomSuffix()
+
+	// Run a container with a tmpfs mount and verify it's writable.
+	out := dockerRun(t, "run", "--name", name,
+		"--mount", "type=tmpfs,target=/scratch",
+		"busybox", "sh", "-c", "echo tmpfs-ok > /scratch/test.txt && cat /scratch/test.txt")
+	defer dockerCmd("rm", "-f", name).Run()
+
+	if !strings.Contains(out, "tmpfs-ok") {
+		t.Errorf("expected 'tmpfs-ok' in output, got: %s", out)
+	}
+}
+
+func TestRunWithBindMountRejected(t *testing.T) {
+	name := "test-bind-" + randomSuffix()
+
+	// Bind mounts should be rejected.
+	cmd := dockerCmd("run", "--name", name, "-v", "/tmp:/data", "busybox", "true")
+	out, err := cmd.CombinedOutput()
+	defer dockerCmd("rm", "-f", name).Run()
+
+	if err == nil {
+		t.Error("expected bind mount to fail, but it succeeded")
+	}
+	if !strings.Contains(string(out), "bind mounts are not supported") {
+		t.Logf("output: %s", out)
+	}
+}
+
+func TestInspectWithMounts(t *testing.T) {
+	volName := "test-inspvol-" + randomSuffix()
+	name := "test-inspmnt-" + randomSuffix()
+
+	dockerRun(t, "volume", "create", volName)
+	defer dockerCmd("volume", "rm", volName).Run()
+
+	dockerRun(t, "create", "--name", name, "-v", volName+":/data", "busybox", "true")
+	defer dockerCmd("rm", "-f", name).Run()
+
+	out := dockerRun(t, "inspect", name)
+	var inspected []map[string]any
+	if err := json.Unmarshal([]byte(out), &inspected); err != nil {
+		t.Fatalf("failed to parse inspect output: %v", err)
+	}
+	if len(inspected) == 0 {
+		t.Fatal("expected at least one inspect result")
+	}
+
+	mounts, ok := inspected[0]["Mounts"].([]any)
+	if !ok || len(mounts) == 0 {
+		t.Fatalf("expected Mounts in inspect output, got: %v", inspected[0]["Mounts"])
+	}
+	m, _ := mounts[0].(map[string]any)
+	if dest, _ := m["Destination"].(string); dest != "/data" {
+		t.Errorf("expected mount destination /data, got %q", dest)
+	}
+}
+
 // randomSuffix returns a short suffix for unique container names.
 func randomSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano()%100000)


### PR DESCRIPTION
Adds volume CRUD endpoints (create/list/inspect/delete/prune) that map
Docker volumes to PersistentVolumeClaims. Wires volume mounts into
containerCreate supporting named volumes (PVC-backed), anonymous volumes
(emptyDir), tmpfs mounts, and rejecting bind mounts. Updates
containerInspect to return mount information.

https://claude.ai/code/session_01FSsT6744UXSF6Cez91uWpn