### PR TITLE
Implement Docker network API backed by Kubernetes ConfigMaps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/imjasonh/badidea
 
-go 1.25.5
+go 1.25.1
 
 require (
 	cloud.google.com/go/compute/metadata v0.9.0

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -133,6 +133,38 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 		containerMounts = append(containerMounts, mnts...)
 	}
 
+	// Auto-create named volumes that don't exist yet (Docker does this implicitly).
+	for _, v := range podVolumes {
+		if v.PersistentVolumeClaim == nil {
+			continue
+		}
+		claimName := v.PersistentVolumeClaim.ClaimName
+		_, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Get(ctx, claimName, metav1.GetOptions{})
+		if err == nil {
+			continue // already exists
+		}
+		log.With("volume", claimName).Info("auto-creating volume")
+		pvc := &corev1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      claimName,
+				Namespace: volumeNS,
+				Labels:    map[string]string{labelApp: labelAppValue},
+			},
+			Spec: corev1.PersistentVolumeClaimSpec{
+				AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				Resources: corev1.VolumeResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceStorage: resource.MustParse(defaultStorage),
+					},
+				},
+			},
+		}
+		if _, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Create(ctx, pvc, metav1.CreateOptions{}); err != nil {
+			writeError(w, err)
+			return
+		}
+	}
+
 	// Build labels for network membership.
 	podLabels := map[string]string{}
 	if name != "" {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -56,16 +56,10 @@ func (s *Server) imageInspect(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, []struct{}{})
 		return
 	}
-	// GET /images/{name}/json → image inspect stub
-	name := strings.TrimSuffix(rest, "/json")
-	writeJSON(w, http.StatusOK, map[string]any{
-		"Id":           "sha256:badidea",
-		"RepoTags":     []string{name},
-		"Architecture": "amd64",
-		"Os":           "linux",
-		"Size":         0,
-		"RootFS":       map[string]any{"Type": "layers", "Layers": []string{}},
-	})
+	// GET /images/{name}/json → we don't track images; return 404.
+	// Docker CLI will then call POST /images/create (pull) which succeeds,
+	// allowing container creation to proceed.
+	writeJSON(w, http.StatusNotFound, errorResponse{"No such image: " + strings.TrimSuffix(rest, "/json")})
 }
 
 // --- System endpoints ---

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/moby/moby/api/types/container"
 	"github.com/moby/moby/api/types/mount"
+	"github.com/moby/moby/api/types/network"
 	"github.com/moby/moby/api/types/system"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -148,6 +149,18 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 			if netName == "host" {
 				writeJSON(w, http.StatusBadRequest, errorResponse{"host networking is not supported"})
 				return
+			}
+			// Validate the network exists (skip "bridge" — it's implicit).
+			if netName != defaultNetworkName {
+				cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, netName, metav1.GetOptions{})
+				if err != nil {
+					writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
+					return
+				}
+				if cm.Labels[networkConfigMapLabel] != "true" {
+					writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
+					return
+				}
 			}
 			podLabels[networkLabelPrefix+netName] = "true"
 			info := netInfo{}
@@ -349,6 +362,20 @@ func (s *Server) containerInspect(w http.ResponseWriter, r *http.Request) {
 		mounts = append(mounts, mp)
 	}
 
+	// Build NetworkSettings from pod labels.
+	networks := map[string]*network.EndpointSettings{}
+	// All containers are implicitly on bridge.
+	networks["bridge"] = &network.EndpointSettings{
+		NetworkID: "bridge",
+	}
+	for k := range pod.Labels {
+		if netName, ok := networkLabelName(k); ok {
+			networks[netName] = &network.EndpointSettings{
+				NetworkID: netName,
+			}
+		}
+	}
+
 	writeJSON(w, http.StatusOK, container.InspectResponse{
 		ID:     pod.Name,
 		Image:  pod.Spec.Containers[0].Image,
@@ -360,6 +387,9 @@ func (s *Server) containerInspect(w http.ResponseWriter, r *http.Request) {
 			Entrypoint: pod.Spec.Containers[0].Command,
 			Cmd:        pod.Spec.Containers[0].Args,
 			Image:      pod.Spec.Containers[0].Image,
+		},
+		NetworkSettings: &container.NetworkSettings{
+			Networks: networks,
 		},
 	})
 }
@@ -636,6 +666,7 @@ func (s *Server) containerPrune(w http.ResponseWriter, r *http.Request) {
 	var deleted []string
 	for _, pod := range pods.Items {
 		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			s.cleanupPodServices(ctx, pod.Name)
 			if err := s.deletePod(ctx, pod.Name); err == nil {
 				deleted = append(deleted, pod.Name)
 			}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -132,8 +132,39 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 		containerMounts = append(containerMounts, mnts...)
 	}
 
+	// Build labels for network membership.
+	podLabels := map[string]string{}
+	if name != "" {
+		podLabels["badidea.dev/pod-name"] = name
+	}
+
+	// Collect network names and aliases from NetworkingConfig.
+	type netInfo struct {
+		aliases []string
+	}
+	networkInfos := map[string]netInfo{}
+	if req.NetworkingConfig != nil {
+		for netName, epConfig := range req.NetworkingConfig.EndpointsConfig {
+			if netName == "host" {
+				writeJSON(w, http.StatusBadRequest, errorResponse{"host networking is not supported"})
+				return
+			}
+			podLabels[networkLabelPrefix+netName] = "true"
+			info := netInfo{}
+			if epConfig != nil {
+				info.aliases = epConfig.Aliases
+			}
+			networkInfos[netName] = info
+		}
+	}
+
+	// If no network specified, pod is on bridge by default (implicit).
+
 	pod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: name},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: podLabels,
+		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyNever,
 			Volumes:       podVolumes,
@@ -157,6 +188,46 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+
+	// Create headless services for DNS resolution when a pod is on a named network.
+	if len(networkInfos) > 0 && pod.Name != "" {
+		if err := s.ensureHeadlessService(ctx, pod.Name, pod.Name); err != nil {
+			log.Warnf("failed to create headless service for pod: %v", err)
+		}
+		// Create alias services.
+		for _, info := range networkInfos {
+			for _, alias := range info.aliases {
+				if err := s.ensureHeadlessService(ctx, alias, pod.Name); err != nil {
+					log.Warnf("failed to create alias service %s: %v", alias, err)
+				}
+			}
+		}
+	}
+
+	// Create port mapping services if HostConfig has PortBindings.
+	if req.HostConfig != nil && len(req.HostConfig.PortBindings) > 0 && pod.Name != "" {
+		var mappings []portMapping
+		for port, bindings := range req.HostConfig.PortBindings {
+			cPort := int(port.Num())
+			proto := strings.ToUpper(string(port.Proto()))
+			for _, b := range bindings {
+				hostPort := 0
+				fmt.Sscanf(b.HostPort, "%d", &hostPort)
+				if hostPort == 0 {
+					hostPort = cPort
+				}
+				mappings = append(mappings, portMapping{
+					hostPort:      hostPort,
+					containerPort: cPort,
+					protocol:      proto,
+				})
+			}
+		}
+		if err := s.createPortMappingService(ctx, pod.Name, mappings); err != nil {
+			log.Warnf("failed to create port mapping service: %v", err)
+		}
+	}
+
 	writeJSON(w, http.StatusCreated, container.CreateResponse{ID: pod.Name})
 }
 
@@ -174,8 +245,10 @@ func (s *Server) containerStart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) containerStop(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	name := r.PathValue("name")
-	if err := s.deletePod(r.Context(), name); err != nil {
+	s.cleanupPodServices(ctx, name)
+	if err := s.deletePod(ctx, name); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -186,6 +259,7 @@ func (s *Server) containerKill(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
 	clog.FromContext(ctx).With("name", name).Info("killing pod")
+	s.cleanupPodServices(ctx, name)
 	zero := int64(0)
 	if err := s.clientset.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{
 		GracePeriodSeconds: &zero,
@@ -201,8 +275,10 @@ func (s *Server) containerRestart(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) containerRm(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	name := r.PathValue("name")
-	if err := s.deletePod(r.Context(), name); err != nil {
+	s.cleanupPodServices(ctx, name)
+	if err := s.deletePod(ctx, name); err != nil {
 		writeError(w, err)
 		return
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -23,6 +23,51 @@ import (
 	"k8s.io/kubectl/pkg/scheme"
 )
 
+// --- Image endpoints (stubs) ---
+// The Docker CLI checks for images before creating containers.
+// Since Kubernetes pulls images via kubelet, we stub these so the CLI doesn't fail.
+
+func (s *Server) imagePull(w http.ResponseWriter, r *http.Request) {
+	// Docker CLI expects a streaming JSON response for image pull.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	fromImage := r.URL.Query().Get("fromImage")
+	tag := r.URL.Query().Get("tag")
+	if tag == "" {
+		tag = "latest"
+	}
+	ref := fromImage + ":" + tag
+	for _, status := range []string{
+		fmt.Sprintf(`{"status":"Pulling from %s","id":"%s"}`, fromImage, tag),
+		fmt.Sprintf(`{"status":"Status: Image is up to date for %s"}`, ref),
+	} {
+		fmt.Fprintln(w, status)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) imageInspect(w http.ResponseWriter, r *http.Request) {
+	rest := r.PathValue("rest")
+	// GET /images/json → image list
+	if rest == "json" {
+		writeJSON(w, http.StatusOK, []struct{}{})
+		return
+	}
+	// GET /images/{name}/json → image inspect stub
+	name := strings.TrimSuffix(rest, "/json")
+	writeJSON(w, http.StatusOK, map[string]any{
+		"Id":           "sha256:badidea",
+		"RepoTags":     []string{name},
+		"Architecture": "amd64",
+		"Os":           "linux",
+		"Size":         0,
+		"RootFS":       map[string]any{"Type": "layers", "Layers": []string{}},
+	})
+}
+
 // --- System endpoints ---
 
 func (s *Server) ping(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -146,29 +146,47 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 	networkInfos := map[string]netInfo{}
 	if req.NetworkingConfig != nil {
 		for netName, epConfig := range req.NetworkingConfig.EndpointsConfig {
-			if netName == "host" {
-				writeJSON(w, http.StatusBadRequest, errorResponse{"host networking is not supported"})
-				return
-			}
-			// Validate the network exists (skip "bridge" — it's implicit).
-			if netName != defaultNetworkName {
-				cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, netName, metav1.GetOptions{})
-				if err != nil {
-					writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
-					return
-				}
-				if cm.Labels[networkConfigMapLabel] != "true" {
-					writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
-					return
-				}
-			}
-			podLabels[networkLabelPrefix+netName] = "true"
 			info := netInfo{}
 			if epConfig != nil {
 				info.aliases = epConfig.Aliases
 			}
 			networkInfos[netName] = info
 		}
+	}
+
+	// Also handle HostConfig.NetworkMode (docker CLI sends --network here).
+	if req.HostConfig != nil && req.HostConfig.NetworkMode != "" {
+		nm := string(req.HostConfig.NetworkMode)
+		if nm != "default" && nm != "bridge" {
+			if _, exists := networkInfos[nm]; !exists {
+				networkInfos[nm] = netInfo{}
+			}
+		}
+	}
+
+	// Validate all networks and build pod labels.
+	for netName := range networkInfos {
+		if netName == "host" {
+			writeJSON(w, http.StatusBadRequest, errorResponse{"host networking is not supported"})
+			return
+		}
+		if netName == "none" {
+			// "none" network means no networking; just skip label.
+			continue
+		}
+		// Validate the network exists (skip "bridge" — it's implicit).
+		if netName != defaultNetworkName {
+			cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, netName, metav1.GetOptions{})
+			if err != nil {
+				writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
+				return
+			}
+			if cm.Labels[networkConfigMapLabel] != "true" {
+				writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", netName)})
+				return
+			}
+		}
+		podLabels[networkLabelPrefix+netName] = "true"
 	}
 
 	// If no network specified, pod is on bridge by default (implicit).

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -417,6 +417,9 @@ func (s *Server) containerList(w http.ResponseWriter, r *http.Request) {
 	}
 	containers := make([]container.Summary, 0, len(pods.Items))
 	for _, pod := range pods.Items {
+		if pod.DeletionTimestamp != nil {
+			continue // skip terminating pods
+		}
 		containers = append(containers, podToSummary(&pod))
 	}
 	writeJSON(w, http.StatusOK, containers)
@@ -430,6 +433,11 @@ func (s *Server) containerInspect(w http.ResponseWriter, r *http.Request) {
 	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		writeError(w, err)
+		return
+	}
+	// Pods with a deletion timestamp are "Terminating" — treat as not found.
+	if pod.DeletionTimestamp != nil {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("No such container: %s", name)})
 		return
 	}
 
@@ -784,7 +792,10 @@ func (s *Server) containerPrune(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deletePod(ctx context.Context, name string) error {
 	clog.FromContext(ctx).With("name", name).Info("deleting pod")
-	return s.clientset.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{})
+	zero := int64(0)
+	return s.clientset.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+	})
 }
 
 func (s *Server) waitForRunning(ctx context.Context, name string) error {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -223,6 +223,10 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 	networkInfos := map[string]netInfo{}
 	if req.NetworkingConfig != nil {
 		for netName, epConfig := range req.NetworkingConfig.EndpointsConfig {
+			// Docker CLI sends "default" to mean the default bridge network.
+			if netName == "default" {
+				netName = defaultNetworkName
+			}
 			info := netInfo{}
 			if epConfig != nil {
 				info.aliases = epConfig.Aliases
@@ -234,7 +238,10 @@ func (s *Server) containerCreate(w http.ResponseWriter, r *http.Request) {
 	// Also handle HostConfig.NetworkMode (docker CLI sends --network here).
 	if req.HostConfig != nil && req.HostConfig.NetworkMode != "" {
 		nm := string(req.HostConfig.NetworkMode)
-		if nm != "default" && nm != "bridge" {
+		if nm == "default" {
+			nm = defaultNetworkName
+		}
+		if nm != defaultNetworkName {
 			if _, exists := networkInfos[nm]; !exists {
 				networkInfos[nm] = netInfo{}
 			}

--- a/internal/server/networks.go
+++ b/internal/server/networks.go
@@ -317,6 +317,10 @@ func (s *Server) networkConnect(w http.ResponseWriter, r *http.Request) {
 		pod.Labels = map[string]string{}
 	}
 	pod.Labels[networkLabelPrefix+id] = "true"
+	// Ensure pod-name label exists so headless Service selectors work.
+	if pod.Labels["badidea.dev/pod-name"] == "" {
+		pod.Labels["badidea.dev/pod-name"] = pod.Name
+	}
 
 	if _, err := s.clientset.CoreV1().Pods(networkNS).Update(ctx, pod, metav1.UpdateOptions{}); err != nil {
 		writeError(w, err)

--- a/internal/server/networks.go
+++ b/internal/server/networks.go
@@ -1,0 +1,498 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/moby/moby/api/types/network"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const (
+	// networkLabelPrefix is the label prefix used to mark pods as members of a network.
+	networkLabelPrefix = "badidea.network/"
+
+	// networkConfigMapLabel identifies ConfigMaps that represent Docker networks.
+	networkConfigMapLabel = "badidea.dev/network"
+
+	// networkNS is the namespace used for network ConfigMaps.
+	networkNS = "default"
+
+	// defaultNetworkName is the default Docker bridge network.
+	defaultNetworkName = "bridge"
+)
+
+// configMapToNetwork converts a ConfigMap to a Docker network inspect response.
+func configMapToNetwork(cm *corev1.ConfigMap) network.Inspect {
+	created := cm.CreationTimestamp.Time
+	n := network.Inspect{
+		Network: network.Network{
+			Name:       cm.Name,
+			ID:         cm.Name,
+			Created:    created,
+			Scope:      "local",
+			Driver:     cm.Data["driver"],
+			EnableIPv4: true,
+			Internal:   cm.Data["internal"] == "true",
+			Options:    map[string]string{},
+			Labels:     map[string]string{},
+		},
+		Containers: map[string]network.EndpointResource{},
+	}
+	for k, v := range cm.Labels {
+		if k != networkConfigMapLabel && k != labelApp {
+			n.Labels[k] = v
+		}
+	}
+	return n
+}
+
+// ensureDefaultNetwork creates the default "bridge" network ConfigMap if it doesn't exist.
+func (s *Server) ensureDefaultNetwork(ctx context.Context) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultNetworkName,
+			Namespace: networkNS,
+			Labels: map[string]string{
+				labelApp:              labelAppValue,
+				networkConfigMapLabel: "true",
+			},
+		},
+		Data: map[string]string{
+			"driver": "bridge",
+		},
+	}
+	_, err := s.clientset.CoreV1().ConfigMaps(networkNS).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
+		clog.FromContext(ctx).Warnf("failed to ensure default bridge network: %v", err)
+	}
+}
+
+// --- Network endpoints ---
+
+func (s *Server) networkList(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clog.FromContext(ctx).Info("listing networks")
+
+	s.ensureDefaultNetwork(ctx)
+
+	cms, err := s.clientset.CoreV1().ConfigMaps(networkNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", networkConfigMapLabel),
+	})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	pods, err := s.clientset.CoreV1().Pods(networkNS).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	networks := make([]network.Inspect, 0, len(cms.Items))
+	for i := range cms.Items {
+		n := configMapToNetwork(&cms.Items[i])
+		for _, pod := range pods.Items {
+			if podOnNetwork(&pod, cms.Items[i].Name) {
+				n.Containers[pod.Name] = network.EndpointResource{
+					Name: pod.Name,
+				}
+			}
+		}
+		networks = append(networks, n)
+	}
+
+	writeJSON(w, http.StatusOK, networks)
+}
+
+func (s *Server) networkCreate(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	var req network.CreateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+		return
+	}
+	if req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"network name is required"})
+		return
+	}
+
+	clog.FromContext(ctx).With("name", req.Name).Info("creating network")
+
+	if req.Name == "host" {
+		writeJSON(w, http.StatusForbidden, errorResponse{"host networking is not supported"})
+		return
+	}
+
+	driver := req.Driver
+	if driver == "" {
+		driver = "bridge"
+	}
+
+	labels := map[string]string{
+		labelApp:              labelAppValue,
+		networkConfigMapLabel: "true",
+	}
+	for k, v := range req.Labels {
+		labels[k] = v
+	}
+
+	data := map[string]string{
+		"driver": driver,
+	}
+	if req.Internal {
+		data["internal"] = "true"
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      req.Name,
+			Namespace: networkNS,
+			Labels:    labels,
+		},
+		Data: data,
+	}
+
+	_, err := s.clientset.CoreV1().ConfigMaps(networkNS).Create(ctx, cm, metav1.CreateOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, network.CreateResponse{
+		ID:      req.Name,
+		Warning: "",
+	})
+}
+
+func (s *Server) networkInspect(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+	clog.FromContext(ctx).With("id", id).Info("inspecting network")
+
+	if id == defaultNetworkName {
+		s.ensureDefaultNetwork(ctx)
+	}
+
+	cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if cm.Labels[networkConfigMapLabel] != "true" {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", id)})
+		return
+	}
+
+	n := configMapToNetwork(cm)
+
+	pods, err := s.clientset.CoreV1().Pods(networkNS).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	for _, pod := range pods.Items {
+		if podOnNetwork(&pod, id) {
+			n.Containers[pod.Name] = network.EndpointResource{
+				Name: pod.Name,
+			}
+		}
+	}
+
+	writeJSON(w, http.StatusOK, n)
+}
+
+func (s *Server) networkDelete(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+	clog.FromContext(ctx).With("id", id).Info("deleting network")
+
+	if id == defaultNetworkName {
+		writeJSON(w, http.StatusForbidden, errorResponse{"cannot remove default bridge network"})
+		return
+	}
+
+	cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if cm.Labels[networkConfigMapLabel] != "true" {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", id)})
+		return
+	}
+
+	if err := s.clientset.CoreV1().ConfigMaps(networkNS).Delete(ctx, id, metav1.DeleteOptions{}); err != nil {
+		writeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) networkPrune(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	clog.FromContext(ctx).Info("pruning networks")
+
+	cms, err := s.clientset.CoreV1().ConfigMaps(networkNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=true", networkConfigMapLabel),
+	})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	pods, err := s.clientset.CoreV1().Pods(networkNS).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	inUse := map[string]bool{defaultNetworkName: true}
+	for _, pod := range pods.Items {
+		if pod.Status.Phase == corev1.PodRunning || pod.Status.Phase == corev1.PodPending {
+			for k := range pod.Labels {
+				if name, ok := networkLabelName(k); ok {
+					inUse[name] = true
+				}
+			}
+		}
+	}
+
+	var deleted []string
+	for _, cm := range cms.Items {
+		if inUse[cm.Name] {
+			continue
+		}
+		if err := s.clientset.CoreV1().ConfigMaps(networkNS).Delete(ctx, cm.Name, metav1.DeleteOptions{}); err == nil {
+			deleted = append(deleted, cm.Name)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, network.PruneReport{
+		NetworksDeleted: deleted,
+	})
+}
+
+func (s *Server) networkConnect(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+
+	var req network.ConnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+		return
+	}
+
+	clog.FromContext(ctx).With("network", id, "container", req.Container).Info("connecting container to network")
+
+	if id == defaultNetworkName {
+		s.ensureDefaultNetwork(ctx)
+	}
+	cm, err := s.clientset.CoreV1().ConfigMaps(networkNS).Get(ctx, id, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if cm.Labels[networkConfigMapLabel] != "true" {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("network %s not found", id)})
+		return
+	}
+
+	pod, err := s.clientset.CoreV1().Pods(networkNS).Get(ctx, req.Container, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	if pod.Labels == nil {
+		pod.Labels = map[string]string{}
+	}
+	pod.Labels[networkLabelPrefix+id] = "true"
+
+	if _, err := s.clientset.CoreV1().Pods(networkNS).Update(ctx, pod, metav1.UpdateOptions{}); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	// Create headless service for DNS.
+	if err := s.ensureHeadlessService(ctx, pod.Name, pod.Name); err != nil {
+		clog.FromContext(ctx).Warnf("failed to create headless service: %v", err)
+	}
+
+	// Create services for aliases.
+	if req.EndpointConfig != nil {
+		for _, alias := range req.EndpointConfig.Aliases {
+			if err := s.ensureHeadlessService(ctx, alias, pod.Name); err != nil {
+				clog.FromContext(ctx).Warnf("failed to create alias service %s: %v", alias, err)
+			}
+		}
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) networkDisconnect(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := r.PathValue("id")
+
+	var req network.DisconnectRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, errorResponse{err.Error()})
+		return
+	}
+
+	clog.FromContext(ctx).With("network", id, "container", req.Container).Info("disconnecting container from network")
+
+	pod, err := s.clientset.CoreV1().Pods(networkNS).Get(ctx, req.Container, metav1.GetOptions{})
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	delete(pod.Labels, networkLabelPrefix+id)
+
+	if _, err := s.clientset.CoreV1().Pods(networkNS).Update(ctx, pod, metav1.UpdateOptions{}); err != nil {
+		writeError(w, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// --- Helpers ---
+
+// networkLabelName extracts the network name from a label key like "badidea.network/mynet".
+func networkLabelName(key string) (string, bool) {
+	if strings.HasPrefix(key, networkLabelPrefix) {
+		name := key[len(networkLabelPrefix):]
+		if name == "" {
+			return "", false
+		}
+		return name, true
+	}
+	return "", false
+}
+
+// podOnNetwork returns true if a pod is a member of the named network.
+// All pods are implicitly on the "bridge" network.
+func podOnNetwork(pod *corev1.Pod, networkName string) bool {
+	if networkName == defaultNetworkName {
+		return true
+	}
+	return pod.Labels[networkLabelPrefix+networkName] == "true"
+}
+
+// ensureHeadlessService creates a headless Service (ClusterIP: None) for DNS resolution.
+func (s *Server) ensureHeadlessService(ctx context.Context, serviceName, podName string) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceName,
+			Namespace: networkNS,
+			Labels: map[string]string{
+				labelApp:                     labelAppValue,
+				"badidea.dev/headless-for":   podName,
+				"badidea.dev/service-reason": "dns",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: "None",
+			Selector: map[string]string{
+				"badidea.dev/pod-name": podName,
+			},
+			Ports: []corev1.ServicePort{{
+				Port:     80,
+				Protocol: corev1.ProtocolTCP,
+			}},
+		},
+	}
+	_, err := s.clientset.CoreV1().Services(networkNS).Create(ctx, svc, metav1.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+// cleanupPodServices deletes headless/port-mapping Services created for a pod.
+func (s *Server) cleanupPodServices(ctx context.Context, podName string) {
+	svcs, err := s.clientset.CoreV1().Services(networkNS).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("badidea.dev/headless-for=%s", podName),
+	})
+	if err != nil {
+		clog.FromContext(ctx).Warnf("failed to list services for pod %s: %v", podName, err)
+		return
+	}
+	for _, svc := range svcs.Items {
+		if err := s.clientset.CoreV1().Services(networkNS).Delete(ctx, svc.Name, metav1.DeleteOptions{}); err != nil {
+			clog.FromContext(ctx).Warnf("failed to delete service %s: %v", svc.Name, err)
+		}
+	}
+}
+
+// createPortMappingService creates a ClusterIP Service for Docker -p port mappings.
+func (s *Server) createPortMappingService(ctx context.Context, podName string, portMappings []portMapping) error {
+	if len(portMappings) == 0 {
+		return nil
+	}
+
+	var ports []corev1.ServicePort
+	for i, pm := range portMappings {
+		ports = append(ports, corev1.ServicePort{
+			Name:       fmt.Sprintf("port-%d", i),
+			Port:       int32(pm.hostPort),
+			TargetPort: intstr.FromInt32(int32(pm.containerPort)),
+			Protocol:   corev1.Protocol(pm.protocol),
+		})
+	}
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-ports", podName),
+			Namespace: networkNS,
+			Labels: map[string]string{
+				labelApp:                     labelAppValue,
+				"badidea.dev/headless-for":   podName,
+				"badidea.dev/service-reason": "ports",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Type: corev1.ServiceTypeClusterIP,
+			Selector: map[string]string{
+				"badidea.dev/pod-name": podName,
+			},
+			Ports: ports,
+		},
+	}
+	_, err := s.clientset.CoreV1().Services(networkNS).Create(ctx, svc, metav1.CreateOptions{})
+	if k8serrors.IsAlreadyExists(err) {
+		return nil
+	}
+	return err
+}
+
+type portMapping struct {
+	hostPort      int
+	containerPort int
+	protocol      string
+}
+
+// parsePortProto parses "80/tcp" into port and protocol.
+func parsePortProto(s string) (int, string) {
+	proto := "TCP"
+	portStr := s
+	if idx := strings.LastIndex(s, "/"); idx > 0 {
+		proto = strings.ToUpper(s[idx+1:])
+		portStr = s[:idx]
+	}
+	var port int
+	fmt.Sscanf(portStr, "%d", &port)
+	return port, proto
+}

--- a/internal/server/networks_test.go
+++ b/internal/server/networks_test.go
@@ -706,3 +706,132 @@ func TestParsePortProto(t *testing.T) {
 		}
 	}
 }
+
+func TestContainerCreateWithNonexistentNetwork(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=badnet",
+		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"nope": {}}}}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("nonexistent network: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestContainerInspectNetworkSettings(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	// Create container on mynet.
+	resp := request(t, ts, "POST", "/containers/create?name=netinspect",
+		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"mynet": {}}}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	// Inspect should show NetworkSettings with both bridge and mynet.
+	resp = request(t, ts, "GET", "/containers/netinspect/json", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if ir.NetworkSettings == nil {
+		t.Fatal("NetworkSettings is nil")
+	}
+	if _, ok := ir.NetworkSettings.Networks["bridge"]; !ok {
+		t.Error("expected bridge in NetworkSettings.Networks")
+	}
+	if _, ok := ir.NetworkSettings.Networks["mynet"]; !ok {
+		t.Error("expected mynet in NetworkSettings.Networks")
+	}
+}
+
+func TestContainerInspectDefaultNetworkSettings(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	// Create container without a network.
+	resp := request(t, ts, "POST", "/containers/create?name=nonet",
+		`{"Image": "alpine"}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	// Inspect should show bridge only.
+	resp = request(t, ts, "GET", "/containers/nonet/json", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if ir.NetworkSettings == nil {
+		t.Fatal("NetworkSettings is nil")
+	}
+	if len(ir.NetworkSettings.Networks) != 1 {
+		t.Errorf("got %d networks, want 1 (bridge only)", len(ir.NetworkSettings.Networks))
+	}
+	if _, ok := ir.NetworkSettings.Networks["bridge"]; !ok {
+		t.Error("expected bridge in NetworkSettings.Networks")
+	}
+}
+
+func TestNetworkConnectAddsPodNameLabel(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	// Pod created WITHOUT badidea.dev/pod-name label (simulating a pod
+	// created before network support was added).
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "oldpod",
+				Namespace: "default",
+				Labels:    map[string]string{},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/mynet/connect",
+		`{"Container": "oldpod"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("connect: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Inspect the pod to verify it has the pod-name label.
+	resp = request(t, ts, "GET", "/containers/oldpod/json", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if ir.NetworkSettings == nil {
+		t.Fatal("NetworkSettings is nil")
+	}
+	if _, ok := ir.NetworkSettings.Networks["mynet"]; !ok {
+		t.Error("expected mynet in NetworkSettings after connect")
+	}
+}

--- a/internal/server/networks_test.go
+++ b/internal/server/networks_test.go
@@ -897,3 +897,32 @@ func TestNetworkConnectAddsPodNameLabel(t *testing.T) {
 		t.Error("expected mynet in NetworkSettings after connect")
 	}
 }
+
+func TestContainerCreateWithDefaultNetworkMode(t *testing.T) {
+	// Docker CLI sends NetworkMode: "default" and EndpointsConfig: {"default": {}}
+	// for containers created without --network. This should succeed (mapped to bridge).
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=default-net",
+		`{"Image": "alpine", "HostConfig": {"NetworkMode": "default"}, "NetworkingConfig": {"EndpointsConfig": {"default": {}}}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create with default network: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	resp.Body.Close()
+}
+
+func TestContainerCreateWithDefaultEndpointsConfig(t *testing.T) {
+	// Even without NetworkMode, EndpointsConfig with "default" should work.
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=default-ep",
+		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"default": {}}}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create with default EndpointsConfig: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	resp.Body.Close()
+}

--- a/internal/server/networks_test.go
+++ b/internal/server/networks_test.go
@@ -1,0 +1,708 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/rest"
+)
+
+// newTestServerWithObjects creates a test server pre-loaded with pods, ConfigMaps, and Services.
+func newTestServerWithObjects(pods []corev1.Pod, cms []corev1.ConfigMap, svcs []corev1.Service) *httptest.Server {
+	clientset := fake.NewSimpleClientset()
+	for i := range pods {
+		clientset.Tracker().Add(&pods[i])
+	}
+	for i := range cms {
+		clientset.Tracker().Add(&cms[i])
+	}
+	for i := range svcs {
+		clientset.Tracker().Add(&svcs[i])
+	}
+	s := New(clientset, rest.Config{})
+	return httptest.NewServer(s.Handler())
+}
+
+func TestNetworkCreateAndInspect(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	// Create a network.
+	resp := request(t, ts, "POST", "/networks/create",
+		`{"Name": "mynet", "Driver": "bridge", "Labels": {"env": "test"}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	cr := decodeJSON[network.CreateResponse](t, resp)
+	if cr.ID != "mynet" {
+		t.Errorf("id: got %q, want %q", cr.ID, "mynet")
+	}
+
+	// Inspect.
+	resp = request(t, ts, "GET", "/networks/mynet", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if n.Name != "mynet" {
+		t.Errorf("name: got %q, want %q", n.Name, "mynet")
+	}
+	if n.Driver != "bridge" {
+		t.Errorf("driver: got %q, want %q", n.Driver, "bridge")
+	}
+	if n.Labels["env"] != "test" {
+		t.Errorf("labels: got %v, want env=test", n.Labels)
+	}
+}
+
+func TestNetworkCreateMissingName(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/create", `{}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestNetworkCreateDuplicate(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/create", `{"Name": "dup"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("first create: got %d", resp.StatusCode)
+	}
+
+	resp = request(t, ts, "POST", "/networks/create", `{"Name": "dup"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Errorf("duplicate: got %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+func TestNetworkCreateHostRejected(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/create", `{"Name": "host"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("host: got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestNetworkInspectNotFound(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks/nope", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNetworkDelete(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "todelete",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/networks/todelete", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Errorf("delete: got %d, want %d", resp.StatusCode, http.StatusNoContent)
+	}
+
+	// Verify gone.
+	resp = request(t, ts, "GET", "/networks/todelete", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("inspect after delete: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNetworkDeleteBridgeRejected(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/networks/bridge", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusForbidden)
+	}
+}
+
+func TestNetworkDeleteNotFound(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/networks/nope", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNetworkList(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "net-a",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "net-b",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "overlay"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	networks := decodeJSON[[]network.Inspect](t, resp)
+	// Should include at least the 2 pre-created + bridge (auto-created).
+	if len(networks) < 2 {
+		t.Errorf("got %d networks, want at least 2", len(networks))
+	}
+}
+
+func TestNetworkListIncludesDefaultBridge(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d", resp.StatusCode)
+	}
+	networks := decodeJSON[[]network.Inspect](t, resp)
+	found := false
+	for _, n := range networks {
+		if n.Name == "bridge" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("default bridge network not found in list")
+	}
+}
+
+func TestNetworkInspectBridgeAutoCreated(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks/bridge", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect bridge: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if n.Name != "bridge" {
+		t.Errorf("name: got %q, want %q", n.Name, "bridge")
+	}
+	if n.Driver != "bridge" {
+		t.Errorf("driver: got %q, want %q", n.Driver, "bridge")
+	}
+}
+
+func TestNetworkPrune(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "unused-net",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "used-net",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mypod",
+				Namespace: "default",
+				Labels:    map[string]string{networkLabelPrefix + "used-net": "true"},
+			},
+			Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+			Status: corev1.PodStatus{Phase: corev1.PodRunning},
+		},
+	}
+	ts := newTestServerWithObjects(pods, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/prune", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("prune: got %d, want %d: %s", resp.StatusCode, http.StatusOK, body)
+	}
+	pr := decodeJSON[network.PruneReport](t, resp)
+	if len(pr.NetworksDeleted) != 1 {
+		t.Errorf("got %d deleted, want 1: %v", len(pr.NetworksDeleted), pr.NetworksDeleted)
+	}
+	if len(pr.NetworksDeleted) > 0 && pr.NetworksDeleted[0] != "unused-net" {
+		t.Errorf("deleted %q, want %q", pr.NetworksDeleted[0], "unused-net")
+	}
+
+	// used-net should still exist.
+	resp = request(t, ts, "GET", "/networks/used-net", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("used-net should still exist, got %d", resp.StatusCode)
+	}
+}
+
+func TestNetworkConnect(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mypod",
+				Namespace: "default",
+				Labels:    map[string]string{"badidea.dev/pod-name": "mypod"},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/mynet/connect",
+		`{"Container": "mypod"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("connect: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Inspect network should show the container.
+	resp = request(t, ts, "GET", "/networks/mynet", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if _, ok := n.Containers["mypod"]; !ok {
+		t.Error("mypod should be in network containers")
+	}
+}
+
+func TestNetworkDisconnect(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mypod",
+				Namespace: "default",
+				Labels: map[string]string{
+					"badidea.dev/pod-name":          "mypod",
+					networkLabelPrefix + "mynet": "true",
+				},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, cms, nil)
+	defer ts.Close()
+
+	// Verify connected first.
+	resp := request(t, ts, "GET", "/networks/mynet", "")
+	n := decodeJSON[network.Inspect](t, resp)
+	if _, ok := n.Containers["mypod"]; !ok {
+		t.Fatal("mypod should be in network before disconnect")
+	}
+
+	// Disconnect.
+	resp = request(t, ts, "POST", "/networks/mynet/disconnect",
+		`{"Container": "mypod"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("disconnect: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	// Verify disconnected.
+	resp = request(t, ts, "GET", "/networks/mynet", "")
+	n = decodeJSON[network.Inspect](t, resp)
+	if _, ok := n.Containers["mypod"]; ok {
+		t.Error("mypod should not be in network after disconnect")
+	}
+}
+
+func TestNetworkConnectNotFoundNetwork(t *testing.T) {
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "mypod", Namespace: "default"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/nope/connect", `{"Container": "mypod"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNetworkConnectNotFoundContainer(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/mynet/connect", `{"Container": "nope"}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestNetworkCreateAndList(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	for _, name := range []string{"net1", "net2"} {
+		resp := request(t, ts, "POST", "/networks/create", `{"Name": "`+name+`"}`)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %s: got %d", name, resp.StatusCode)
+		}
+	}
+
+	resp := request(t, ts, "GET", "/networks", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("list: got %d", resp.StatusCode)
+	}
+	networks := decodeJSON[[]network.Inspect](t, resp)
+	// net1 + net2 + bridge (auto-created)
+	if len(networks) != 3 {
+		t.Errorf("got %d networks, want 3", len(networks))
+	}
+}
+
+func TestNetworkVersionPrefix(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/v1.45/networks/create", `{"Name": "prefixed"}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create with version prefix: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	cr := decodeJSON[network.CreateResponse](t, resp)
+	if cr.ID != "prefixed" {
+		t.Errorf("id: got %q, want %q", cr.ID, "prefixed")
+	}
+}
+
+func TestContainerCreateWithNetwork(t *testing.T) {
+	// Pre-create the network.
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=nettest",
+		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"mynet": {}}}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	cr := decodeJSON[container.CreateResponse](t, resp)
+	if cr.ID != "nettest" {
+		t.Errorf("id: got %q, want %q", cr.ID, "nettest")
+	}
+
+	// The pod should be on the network.
+	resp = request(t, ts, "GET", "/networks/mynet", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect net: got %d", resp.StatusCode)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if _, ok := n.Containers["nettest"]; !ok {
+		t.Error("nettest should be in network containers")
+	}
+}
+
+func TestContainerCreateWithHostNetworkRejected(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=hostnet",
+		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"host": {}}}}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("host network: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
+	}
+}
+
+func TestNetworkInspectShowsContainers(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-a",
+				Namespace: "default",
+				Labels:    map[string]string{networkLabelPrefix + "mynet": "true"},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-b",
+				Namespace: "default",
+				Labels:    map[string]string{},
+			},
+			Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks/mynet", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if len(n.Containers) != 1 {
+		t.Errorf("got %d containers, want 1", len(n.Containers))
+	}
+	if _, ok := n.Containers["pod-a"]; !ok {
+		t.Error("pod-a should be in network containers")
+	}
+}
+
+func TestBridgeNetworkShowsAllContainers(t *testing.T) {
+	pods := []corev1.Pod{
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-a", Namespace: "default"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod-b", Namespace: "default"},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		},
+	}
+	ts := newTestServerWithObjects(pods, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/networks/bridge", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect bridge: got %d: %s", resp.StatusCode, body)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if len(n.Containers) != 2 {
+		t.Errorf("bridge should show all containers: got %d, want 2", len(n.Containers))
+	}
+}
+
+func TestNetworkCreateDefaultDriver(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	// Create without specifying driver; should default to "bridge".
+	resp := request(t, ts, "POST", "/networks/create", `{"Name": "nodriver"}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	resp = request(t, ts, "GET", "/networks/nodriver", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if n.Driver != "bridge" {
+		t.Errorf("driver: got %q, want %q", n.Driver, "bridge")
+	}
+}
+
+func TestNetworkCreateOverlayDriverAccepted(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	// Overlay driver accepted but stored as-is (no effect).
+	resp := request(t, ts, "POST", "/networks/create", `{"Name": "overlay-net", "Driver": "overlay"}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+
+	resp = request(t, ts, "GET", "/networks/overlay-net", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	n := decodeJSON[network.Inspect](t, resp)
+	if n.Driver != "overlay" {
+		t.Errorf("driver: got %q, want %q", n.Driver, "overlay")
+	}
+}
+
+func TestNetworkPruneBridgeNeverPruned(t *testing.T) {
+	// Create only a bridge ConfigMap (no pods reference it).
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bridge",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/networks/prune", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("prune: got %d", resp.StatusCode)
+	}
+	pr := decodeJSON[network.PruneReport](t, resp)
+	for _, name := range pr.NetworksDeleted {
+		if name == "bridge" {
+			t.Error("bridge network should never be pruned")
+		}
+	}
+}
+
+// --- Helper unit tests ---
+
+func TestNetworkLabelName(t *testing.T) {
+	tests := []struct {
+		key      string
+		wantName string
+		wantOK   bool
+	}{
+		{"badidea.network/mynet", "mynet", true},
+		{"badidea.network/bridge", "bridge", true},
+		{"other-label", "", false},
+		{"badidea.network/", "", false},
+	}
+	for _, tt := range tests {
+		name, ok := networkLabelName(tt.key)
+		if ok != tt.wantOK || name != tt.wantName {
+			t.Errorf("networkLabelName(%q) = %q, %v; want %q, %v", tt.key, name, ok, tt.wantName, tt.wantOK)
+		}
+	}
+}
+
+func TestPodOnNetwork(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				networkLabelPrefix + "mynet": "true",
+			},
+		},
+	}
+
+	if !podOnNetwork(pod, "bridge") {
+		t.Error("all pods should be on bridge")
+	}
+	if !podOnNetwork(pod, "mynet") {
+		t.Error("pod should be on mynet")
+	}
+	if podOnNetwork(pod, "other") {
+		t.Error("pod should not be on other")
+	}
+}
+
+func TestParsePortProto(t *testing.T) {
+	tests := []struct {
+		input     string
+		wantPort  int
+		wantProto string
+	}{
+		{"80/tcp", 80, "TCP"},
+		{"443/udp", 443, "UDP"},
+		{"8080", 8080, "TCP"},
+	}
+	for _, tt := range tests {
+		port, proto := parsePortProto(tt.input)
+		if port != tt.wantPort || proto != tt.wantProto {
+			t.Errorf("parsePortProto(%q) = %d, %q; want %d, %q", tt.input, port, proto, tt.wantPort, tt.wantProto)
+		}
+	}
+}

--- a/internal/server/networks_test.go
+++ b/internal/server/networks_test.go
@@ -715,7 +715,69 @@ func TestContainerCreateWithNonexistentNetwork(t *testing.T) {
 		`{"Image": "alpine", "NetworkingConfig": {"EndpointsConfig": {"nope": {}}}}`)
 	resp.Body.Close()
 	if resp.StatusCode != http.StatusNotFound {
-		t.Errorf("nonexistent network: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+		t.Errorf("nonexistent network via EndpointsConfig: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestContainerCreateWithNonexistentNetworkMode(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	// Docker CLI sends --network via HostConfig.NetworkMode.
+	resp := request(t, ts, "POST", "/containers/create?name=badmode",
+		`{"Image": "alpine", "HostConfig": {"NetworkMode": "nope"}}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("nonexistent network via NetworkMode: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestContainerCreateWithNetworkMode(t *testing.T) {
+	cms := []corev1.ConfigMap{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "mynet",
+				Namespace: "default",
+				Labels:    map[string]string{labelApp: labelAppValue, networkConfigMapLabel: "true"},
+			},
+			Data: map[string]string{"driver": "bridge"},
+		},
+	}
+	ts := newTestServerWithObjects(nil, cms, nil)
+	defer ts.Close()
+
+	// Docker CLI sends --network via HostConfig.NetworkMode (not just EndpointsConfig).
+	resp := request(t, ts, "POST", "/containers/create?name=modetest",
+		`{"Image": "alpine", "HostConfig": {"NetworkMode": "mynet"}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+	resp.Body.Close()
+
+	// Inspect should show mynet in NetworkSettings.
+	resp = request(t, ts, "GET", "/containers/modetest/json", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d", resp.StatusCode)
+	}
+	ir := decodeJSON[container.InspectResponse](t, resp)
+	if ir.NetworkSettings == nil {
+		t.Fatal("NetworkSettings is nil")
+	}
+	if _, ok := ir.NetworkSettings.Networks["mynet"]; !ok {
+		t.Errorf("expected mynet in NetworkSettings.Networks, got: %v", ir.NetworkSettings.Networks)
+	}
+}
+
+func TestContainerCreateWithHostNetworkModeRejected(t *testing.T) {
+	ts := newTestServerWithObjects(nil, nil, nil)
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=hostmode",
+		`{"Image": "alpine", "HostConfig": {"NetworkMode": "host"}}`)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("host NetworkMode: got %d, want %d", resp.StatusCode, http.StatusBadRequest)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/moby/moby/api/types/container"
+	"github.com/moby/moby/api/types/network"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
@@ -222,6 +223,20 @@ func podToSummary(pod *corev1.Pod) container.Summary {
 	}
 	if pod.Status.StartTime != nil {
 		c.Created = pod.Status.StartTime.Time.Unix()
+	}
+	// Populate NetworkSettings from pod labels.
+	networks := map[string]*network.EndpointSettings{
+		"bridge": {NetworkID: "bridge"},
+	}
+	for k := range pod.Labels {
+		if netName, ok := networkLabelName(k); ok {
+			networks[netName] = &network.EndpointSettings{
+				NetworkID: netName,
+			}
+		}
+	}
+	c.NetworkSettings = &container.NetworkSettingsSummary{
+		Networks: networks,
 	}
 	return c
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -83,6 +83,10 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /networks/{id}/connect", s.networkConnect)
 	mux.HandleFunc("POST /networks/{id}/disconnect", s.networkDisconnect)
 
+	// Images (stubs — K8s pulls images via kubelet, but Docker CLI needs these)
+	mux.HandleFunc("POST /images/create", s.imagePull)
+	mux.HandleFunc("GET /images/{rest...}", s.imageInspect)
+
 	// The Docker client may prefix requests with /v1.45/ etc.
 	return s.middleware(stripVersionPrefix(mux))
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,6 +73,15 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /volumes/{name}", s.volumeInspect)
 	mux.HandleFunc("DELETE /volumes/{name}", s.volumeDelete)
 
+	// Networks (order matters: /create and /prune before /{id} wildcard)
+	mux.HandleFunc("GET /networks", s.networkList)
+	mux.HandleFunc("POST /networks/create", s.networkCreate)
+	mux.HandleFunc("POST /networks/prune", s.networkPrune)
+	mux.HandleFunc("GET /networks/{id}", s.networkInspect)
+	mux.HandleFunc("DELETE /networks/{id}", s.networkDelete)
+	mux.HandleFunc("POST /networks/{id}/connect", s.networkConnect)
+	mux.HandleFunc("POST /networks/{id}/disconnect", s.networkDisconnect)
+
 	// The Docker client may prefix requests with /v1.45/ etc.
 	return s.middleware(stripVersionPrefix(mux))
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -622,6 +622,59 @@ func TestResponseHeaders(t *testing.T) {
 	}
 }
 
+func TestImagePull(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/images/create?fromImage=busybox&tag=latest", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "busybox") {
+		t.Errorf("expected 'busybox' in pull output, got: %s", body)
+	}
+}
+
+func TestImageInspect(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/images/busybox:latest/json", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
+func TestImageList(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/images/json", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	var images []struct{}
+	json.NewDecoder(resp.Body).Decode(&images)
+	resp.Body.Close()
+	if len(images) != 0 {
+		t.Errorf("got %d images, want 0", len(images))
+	}
+}
+
+func TestImagePullWithVersionPrefix(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/v1.45/images/create?fromImage=alpine&tag=3.18", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+}
+
 func TestStripVersionPrefix(t *testing.T) {
 	tests := []struct {
 		path string

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -637,14 +637,16 @@ func TestImagePull(t *testing.T) {
 	}
 }
 
-func TestImageInspect(t *testing.T) {
+func TestImageInspectReturns404(t *testing.T) {
 	ts := newTestServer()
 	defer ts.Close()
 
+	// We don't track images — inspect always returns 404.
+	// Docker CLI handles this by calling pull, then proceeding.
 	resp := request(t, ts, "GET", "/images/busybox:latest/json", "")
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusOK {
-		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusOK)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("got %d, want %d", resp.StatusCode, http.StatusNotFound)
 	}
 }
 

--- a/internal/server/volumes.go
+++ b/internal/server/volumes.go
@@ -26,16 +26,28 @@ var badideaLabels = map[string]string{labelApp: labelAppValue}
 
 func pvcToVolume(pvc *corev1.PersistentVolumeClaim) volume.Volume {
 	created := pvc.CreationTimestamp.Format(time.RFC3339)
+	// Return only user-supplied labels, not internal management labels.
+	userLabels := make(map[string]string)
+	for k, v := range pvc.Labels {
+		if k != labelApp {
+			userLabels[k] = v
+		}
+	}
 	return volume.Volume{
 		Name:       pvc.Name,
 		Driver:     "local",
 		Mountpoint: "/var/lib/badidea/volumes/" + pvc.Name,
 		CreatedAt:  created,
 		Status:     map[string]any{"phase": string(pvc.Status.Phase)},
-		Labels:     pvc.Labels,
+		Labels:     userLabels,
 		Scope:      "local",
 		Options:    map[string]string{},
 	}
+}
+
+// isBadideaVolume returns true if the PVC was created by badidea.
+func isBadideaVolume(pvc *corev1.PersistentVolumeClaim) bool {
+	return pvc.Labels[labelApp] == labelAppValue
 }
 
 // --- Volume endpoints ---
@@ -121,6 +133,10 @@ func (s *Server) volumeInspect(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	if !isBadideaVolume(pvc) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("volume %s not found", name)})
+		return
+	}
 
 	writeJSON(w, http.StatusOK, pvcToVolume(pvc))
 }
@@ -130,8 +146,18 @@ func (s *Server) volumeDelete(w http.ResponseWriter, r *http.Request) {
 	name := r.PathValue("name")
 	clog.FromContext(ctx).With("name", name).Info("deleting volume")
 
-	err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Delete(ctx, name, metav1.DeleteOptions{})
+	// Verify it's a badidea-managed volume before deleting.
+	pvc, err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if !isBadideaVolume(pvc) {
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("volume %s not found", name)})
+		return
+	}
+
+	if err := s.clientset.CoreV1().PersistentVolumeClaims(volumeNS).Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
 		writeError(w, err)
 		return
 	}
@@ -194,6 +220,7 @@ func (s *Server) volumePrune(w http.ResponseWriter, r *http.Request) {
 func parseBinds(binds []string) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	var volumes []corev1.Volume
 	var mounts []corev1.VolumeMount
+	seenVols := map[string]bool{}
 
 	for _, bind := range binds {
 		parts := strings.SplitN(bind, ":", 3)
@@ -213,15 +240,18 @@ func parseBinds(binds []string) ([]corev1.Volume, []corev1.VolumeMount, error) {
 		}
 
 		volName := "vol-" + source
-		volumes = append(volumes, corev1.Volume{
-			Name: volName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: source,
-					ReadOnly:  readOnly,
+		if !seenVols[volName] {
+			volumes = append(volumes, corev1.Volume{
+				Name: volName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+						ClaimName: source,
+						ReadOnly:  readOnly,
+					},
 				},
-			},
-		})
+			})
+			seenVols[volName] = true
+		}
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      volName,
 			MountPath: dest,
@@ -236,6 +266,7 @@ func parseBinds(binds []string) ([]corev1.Volume, []corev1.VolumeMount, error) {
 func parseDockerMounts(mnts []mount.Mount) ([]corev1.Volume, []corev1.VolumeMount, error) {
 	var volumes []corev1.Volume
 	var mounts []corev1.VolumeMount
+	seenVols := map[string]bool{}
 
 	for i, m := range mnts {
 		switch m.Type {
@@ -244,15 +275,18 @@ func parseDockerMounts(mnts []mount.Mount) ([]corev1.Volume, []corev1.VolumeMoun
 				return nil, nil, fmt.Errorf("mount[%d]: volume source is required", i)
 			}
 			volName := "vol-" + m.Source
-			volumes = append(volumes, corev1.Volume{
-				Name: volName,
-				VolumeSource: corev1.VolumeSource{
-					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-						ClaimName: m.Source,
-						ReadOnly:  m.ReadOnly,
+			if !seenVols[volName] {
+				volumes = append(volumes, corev1.Volume{
+					Name: volName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: m.Source,
+							ReadOnly:  m.ReadOnly,
+						},
 					},
-				},
-			})
+				})
+				seenVols[volName] = true
+			}
 			mounts = append(mounts, corev1.VolumeMount{
 				Name:      volName,
 				MountPath: m.Target,

--- a/internal/server/volumes_test.go
+++ b/internal/server/volumes_test.go
@@ -51,8 +51,8 @@ func TestVolumeCreateAndInspect(t *testing.T) {
 	if v.Labels["env"] != "test" {
 		t.Errorf("labels: got %v, want env=test", v.Labels)
 	}
-	if v.Labels[labelApp] != labelAppValue {
-		t.Errorf("labels: missing %s=%s", labelApp, labelAppValue)
+	if _, ok := v.Labels[labelApp]; ok {
+		t.Errorf("internal label %s should be filtered from response", labelApp)
 	}
 
 	// Inspect
@@ -610,5 +610,135 @@ func TestVolumeVersionPrefix(t *testing.T) {
 	v := decodeJSON[volume.Volume](t, resp)
 	if v.Name != "prefixed" {
 		t.Errorf("name: got %q, want %q", v.Name, "prefixed")
+	}
+}
+
+func TestVolumeInspectRejectsNonBadideaPVC(t *testing.T) {
+	// A PVC without the badidea label should not be returned by inspect.
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreign",
+			Namespace: "default",
+			Labels:    map[string]string{"owner": "someone-else"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, []corev1.PersistentVolumeClaim{pvc})
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/volumes/foreign", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("inspect non-badidea PVC: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestVolumeDeleteRejectsNonBadideaPVC(t *testing.T) {
+	// A PVC without the badidea label should not be deletable via the API.
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foreign",
+			Namespace: "default",
+			Labels:    map[string]string{"owner": "someone-else"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, []corev1.PersistentVolumeClaim{pvc})
+	defer ts.Close()
+
+	resp := request(t, ts, "DELETE", "/volumes/foreign", "")
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("delete non-badidea PVC: got %d, want %d", resp.StatusCode, http.StatusNotFound)
+	}
+}
+
+func TestVolumeLabelsFilterInternalLabel(t *testing.T) {
+	// The internal app=badidea label should be filtered from volume responses.
+	pvc := corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "labeled",
+			Namespace: "default",
+			Labels:    map[string]string{labelApp: labelAppValue, "env": "prod"},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+		},
+	}
+	ts := newTestServerWithPVCs(nil, []corev1.PersistentVolumeClaim{pvc})
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/volumes/labeled", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("inspect: got %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	v := decodeJSON[volume.Volume](t, resp)
+	if _, ok := v.Labels[labelApp]; ok {
+		t.Errorf("internal label %q should be filtered", labelApp)
+	}
+	if v.Labels["env"] != "prod" {
+		t.Errorf("user label env: got %q, want %q", v.Labels["env"], "prod")
+	}
+}
+
+func TestParseBindsDeduplicatesSameSource(t *testing.T) {
+	// Same volume mounted to two different paths should produce 1 volume, 2 mounts.
+	binds := []string{"mydata:/path1", "mydata:/path2"}
+	vols, mounts, err := parseBinds(binds)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols) != 1 {
+		t.Errorf("got %d volumes, want 1 (deduplicated)", len(vols))
+	}
+	if len(mounts) != 2 {
+		t.Errorf("got %d mounts, want 2", len(mounts))
+	}
+}
+
+func TestParseDockerMountsDeduplicatesSameSource(t *testing.T) {
+	// Same volume mounted to two different paths should produce 1 volume, 2 mounts.
+	mnts := []mount.Mount{
+		{Type: mount.TypeVolume, Source: "shared", Target: "/a"},
+		{Type: mount.TypeVolume, Source: "shared", Target: "/b"},
+	}
+	vols, mounts, err := parseDockerMounts(mnts)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(vols) != 1 {
+		t.Errorf("got %d volumes, want 1 (deduplicated)", len(vols))
+	}
+	if len(mounts) != 2 {
+		t.Errorf("got %d mounts, want 2", len(mounts))
+	}
+}
+
+func TestContainerCreateAutoCreatesVolume(t *testing.T) {
+	// When a named volume doesn't exist, containerCreate should auto-create it.
+	ts := newTestServerWithPVCs(nil, nil)
+	defer ts.Close()
+
+	// Create container with a volume that doesn't exist yet.
+	resp := request(t, ts, "POST", "/containers/create?name=autocreate-test",
+		`{"Image": "alpine", "HostConfig": {"Binds": ["newvol:/data"]}}`)
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: got %d, want %d: %s", resp.StatusCode, http.StatusCreated, body)
+	}
+
+	// The volume should now be inspectable.
+	resp = request(t, ts, "GET", "/volumes/newvol", "")
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("auto-created volume should exist, got %d", resp.StatusCode)
+	} else {
+		v := decodeJSON[volume.Volume](t, resp)
+		if v.Name != "newvol" {
+			t.Errorf("volume name: got %q, want %q", v.Name, "newvol")
+		}
 	}
 }

--- a/network-plan.md
+++ b/network-plan.md
@@ -105,3 +105,34 @@ Steps 1-3 are the minimum viable feature. Steps 4-7 are nice-to-haves.
   - Answer: No. Just document this shortcoming.
 - Should port mapping use LoadBalancer services for external access? This is slow (30-60s provisioning) and costs money per service. Leaning no -- ClusterIP only for now, with a note that external access is possible via `kubectl port-forward` or by adding LoadBalancer support later.
   - Answer: Agree with your assessment: ClusterIP, document this shortcoming.
+
+## Known limitations (implemented)
+
+These are inherent to the K8s-backed approach and documented here for users:
+
+### No network isolation
+Creating separate Docker networks does **not** provide isolation. Any pod can reach any other pod regardless of network membership. In real Docker, containers on different networks are isolated by default. We could enforce this with NetworkPolicy, but that adds significant complexity and may conflict with cluster-level policies.
+
+### DNS is cluster-wide, not per-network
+Docker scopes DNS names to a network: container `db` on `mynet` is only resolvable by other containers on `mynet`. Our implementation creates a headless Service for the container name, making it resolvable by **any** pod in the namespace, regardless of network membership. This is a fundamental difference from Docker networking.
+
+### Subnet/gateway/IP configuration is ignored
+`docker network create --subnet 10.0.0.0/24 --gateway 10.0.0.1` and similar options are accepted but have no effect. Kubernetes manages pod CIDR ranges at the cluster level.
+
+### `--internal` is accepted but ignored
+Docker internal networks have no outbound connectivity. We store the flag but do not create NetworkPolicy egress rules to enforce it.
+
+### Driver selection has no effect
+`--driver overlay`, `--driver macvlan`, etc. are accepted and stored in the ConfigMap, but all networks behave identically. There are no actual bridges, VXLAN tunnels, or macvlan interfaces.
+
+### Port mapping creates ClusterIP only
+`-p 8080:80` creates a ClusterIP Service, making the port reachable from within the cluster but **not** from outside. For external access, use `kubectl port-forward` or add LoadBalancer support later. Docker's port mapping makes ports reachable on the host immediately.
+
+### ConfigMap name collisions
+Network names occupy the ConfigMap namespace in the `default` namespace. If a ConfigMap with the same name already exists for a non-network purpose, `network create` will fail with a conflict error.
+
+### Service name collisions
+Headless Services for DNS use the container name as the Service name. If a Kubernetes Service with that name already exists (e.g., `kubernetes`), the headless Service creation silently fails and DNS won't work for that container. Network aliases have the same limitation.
+
+### Single namespace
+All networks, pods, and services are in the `default` namespace. Cross-namespace networking is not supported.

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -490,6 +490,131 @@ func TestInspectWithMounts(t *testing.T) {
 	}
 }
 
+// --- Network tests ---
+
+func TestNetworkCreateInspectRm(t *testing.T) {
+	name := "test-net-" + randomSuffix()
+
+	// Create
+	out := dockerRun(t, "network", "create", name)
+	if !strings.Contains(out, name) {
+		t.Errorf("expected network name %q in create output, got: %s", name, out)
+	}
+
+	// Inspect
+	out = dockerRun(t, "network", "inspect", name)
+	var networks []map[string]any
+	if err := json.Unmarshal([]byte(out), &networks); err != nil {
+		t.Fatalf("failed to parse network inspect output: %v", err)
+	}
+	if len(networks) == 0 {
+		t.Fatal("expected at least one network in inspect output")
+	}
+	if got, _ := networks[0]["Name"].(string); got != name {
+		t.Errorf("expected network name %q, got %q", name, got)
+	}
+
+	// Remove
+	dockerRun(t, "network", "rm", name)
+
+	// Verify gone
+	cmd := dockerCmd("network", "inspect", name)
+	if err := cmd.Run(); err == nil {
+		t.Error("expected network inspect to fail after rm, but it succeeded")
+	}
+}
+
+func TestNetworkList(t *testing.T) {
+	name := "test-netls-" + randomSuffix()
+
+	dockerRun(t, "network", "create", name)
+	defer dockerCmd("network", "rm", name).Run()
+
+	out := dockerRun(t, "network", "ls")
+	if !strings.Contains(out, name) {
+		t.Errorf("expected %q in network ls output, got: %s", name, out)
+	}
+}
+
+func TestNetworkListIncludesBridge(t *testing.T) {
+	out := dockerRun(t, "network", "ls")
+	if !strings.Contains(out, "bridge") {
+		t.Errorf("expected 'bridge' in network ls output, got: %s", out)
+	}
+}
+
+func TestNetworkPrune(t *testing.T) {
+	name := "test-netpr-" + randomSuffix()
+
+	dockerRun(t, "network", "create", name)
+
+	// Prune unused networks.
+	out := dockerRun(t, "network", "prune", "-f")
+	t.Logf("network prune output: %s", out)
+
+	// The network should be gone.
+	cmd := dockerCmd("network", "inspect", name)
+	if err := cmd.Run(); err == nil {
+		t.Error("expected network inspect to fail after prune, but it succeeded")
+	}
+}
+
+func TestRunWithNetwork(t *testing.T) {
+	netName := "test-runnet-" + randomSuffix()
+	name := "test-netrun-" + randomSuffix()
+
+	// Create network.
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	// Run a container on the network.
+	out := dockerRun(t, "run", "--name", name, "--network", netName,
+		"busybox", "echo", "hello-net")
+	defer dockerCmd("rm", "-f", name).Run()
+
+	if !strings.Contains(out, "hello-net") {
+		t.Errorf("expected 'hello-net' in output, got: %s", out)
+	}
+}
+
+func TestNetworkConnectDisconnect(t *testing.T) {
+	netName := "test-connnet-" + randomSuffix()
+	name := "test-conn-" + randomSuffix()
+
+	// Create network and container.
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Connect container to network.
+	dockerRun(t, "network", "connect", netName, name)
+
+	// Inspect network to verify container is connected.
+	out := dockerRun(t, "network", "inspect", netName)
+	if !strings.Contains(out, name) {
+		t.Errorf("expected %q in network inspect after connect, got: %s", name, out)
+	}
+
+	// Disconnect.
+	dockerRun(t, "network", "disconnect", netName, name)
+
+	// Verify disconnected.
+	out = dockerRun(t, "network", "inspect", netName)
+	var networks []map[string]any
+	if err := json.Unmarshal([]byte(out), &networks); err != nil {
+		t.Fatalf("failed to parse inspect output: %v", err)
+	}
+	if len(networks) > 0 {
+		containers, _ := networks[0]["Containers"].(map[string]any)
+		if _, ok := containers[name]; ok {
+			t.Errorf("container %q should not be in network after disconnect", name)
+		}
+	}
+}
+
 // randomSuffix returns a short suffix for unique container names.
 func randomSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano()%100000)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -615,6 +615,151 @@ func TestNetworkConnectDisconnect(t *testing.T) {
 	}
 }
 
+func TestRunWithNonexistentNetworkRejected(t *testing.T) {
+	name := "test-nonet-" + randomSuffix()
+
+	cmd := dockerCmd("run", "--name", name, "--network", "does-not-exist", "busybox", "true")
+	out, err := cmd.CombinedOutput()
+	defer dockerCmd("rm", "-f", name).Run()
+
+	if err == nil {
+		t.Error("expected run with nonexistent network to fail, but it succeeded")
+	}
+	t.Logf("output: %s", out)
+}
+
+func TestInspectShowsNetworkSettings(t *testing.T) {
+	netName := "test-inspnet-" + randomSuffix()
+	name := "test-netinsp-" + randomSuffix()
+
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	dockerRun(t, "create", "--name", name, "--network", netName, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	out := dockerRun(t, "inspect", name)
+	var inspected []map[string]any
+	if err := json.Unmarshal([]byte(out), &inspected); err != nil {
+		t.Fatalf("failed to parse inspect output: %v", err)
+	}
+	if len(inspected) == 0 {
+		t.Fatal("expected at least one inspect result")
+	}
+
+	netSettings, ok := inspected[0]["NetworkSettings"].(map[string]any)
+	if !ok {
+		t.Fatal("missing NetworkSettings in inspect output")
+	}
+	networks, ok := netSettings["Networks"].(map[string]any)
+	if !ok {
+		t.Fatal("missing Networks in NetworkSettings")
+	}
+
+	if _, ok := networks["bridge"]; !ok {
+		t.Error("expected 'bridge' in NetworkSettings.Networks")
+	}
+	if _, ok := networks[netName]; !ok {
+		t.Errorf("expected %q in NetworkSettings.Networks, got: %v", netName, networks)
+	}
+}
+
+func TestNetworkConnectShowsInInspect(t *testing.T) {
+	netName := "test-conninsp-" + randomSuffix()
+	name := "test-conninsp-c-" + randomSuffix()
+
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	// Create container WITHOUT --network, then connect after.
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	dockerRun(t, "network", "connect", netName, name)
+
+	// Container inspect should show the network.
+	out := dockerRun(t, "inspect", name)
+	var inspected []map[string]any
+	if err := json.Unmarshal([]byte(out), &inspected); err != nil {
+		t.Fatalf("failed to parse inspect output: %v", err)
+	}
+	netSettings, _ := inspected[0]["NetworkSettings"].(map[string]any)
+	networks, _ := netSettings["Networks"].(map[string]any)
+	if _, ok := networks[netName]; !ok {
+		t.Errorf("expected %q in NetworkSettings.Networks after connect, got: %v", netName, networks)
+	}
+
+	// Network inspect should show the container.
+	out = dockerRun(t, "network", "inspect", netName)
+	if !strings.Contains(out, name) {
+		t.Errorf("expected %q in network inspect after connect, got: %s", name, out)
+	}
+}
+
+func TestContainerDNSViaHeadlessService(t *testing.T) {
+	netName := "test-dns-" + randomSuffix()
+	serverName := "test-dnssrv-" + randomSuffix()
+	clientName := "test-dnscli-" + randomSuffix()
+
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	// Start a "server" container on the network.
+	dockerRun(t, "create", "--name", serverName, "--network", netName,
+		"busybox", "sleep", "300")
+	dockerRun(t, "start", serverName)
+	defer dockerCmd("rm", "-f", serverName).Run()
+
+	// Give the headless service a moment to register.
+	time.Sleep(2 * time.Second)
+
+	// Start a "client" container that tries to resolve the server by name.
+	// nslookup will fail if DNS doesn't resolve, but the container itself
+	// should at least run. We use getent which is available in busybox.
+	out, _ := dockerCmd("run", "--name", clientName, "--network", netName,
+		"busybox", "nslookup", serverName).CombinedOutput()
+	defer dockerCmd("rm", "-f", clientName).Run()
+
+	t.Logf("DNS lookup output: %s", out)
+	// We check that nslookup found something — it should contain the server name.
+	// On failure it would say "server can't find" or "NXDOMAIN".
+	if strings.Contains(string(out), "can't find") || strings.Contains(string(out), "NXDOMAIN") {
+		t.Errorf("DNS resolution failed for %q: %s", serverName, out)
+	}
+}
+
+func TestContainerPruneCleansUpFromNetwork(t *testing.T) {
+	netName := "test-prunenet-" + randomSuffix()
+	name := "test-prunec-" + randomSuffix()
+
+	dockerRun(t, "network", "create", netName)
+	defer dockerCmd("network", "rm", netName).Run()
+
+	// Run a container on the network that exits immediately.
+	dockerRun(t, "run", "--name", name, "--network", netName, "busybox", "true")
+
+	// Wait for it to reach terminal state.
+	time.Sleep(5 * time.Second)
+
+	// Prune exited containers.
+	dockerRun(t, "container", "prune", "-f")
+
+	// The container should no longer appear in network inspect.
+	out := dockerRun(t, "network", "inspect", netName)
+	var networks []map[string]any
+	if err := json.Unmarshal([]byte(out), &networks); err != nil {
+		t.Fatalf("failed to parse inspect output: %v", err)
+	}
+	if len(networks) > 0 {
+		containers, _ := networks[0]["Containers"].(map[string]any)
+		if _, ok := containers[name]; ok {
+			t.Errorf("container %q should not be in network after prune", name)
+		}
+	}
+}
+
 // randomSuffix returns a short suffix for unique container names.
 func randomSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano()%100000)

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -723,10 +723,25 @@ func TestContainerDNSViaHeadlessService(t *testing.T) {
 	defer dockerCmd("rm", "-f", clientName).Run()
 
 	t.Logf("DNS lookup output: %s", out)
-	// We check that nslookup found something — it should contain the server name.
-	// On failure it would say "server can't find" or "NXDOMAIN".
-	if strings.Contains(string(out), "can't find") || strings.Contains(string(out), "NXDOMAIN") {
-		t.Errorf("DNS resolution failed for %q: %s", serverName, out)
+	// nslookup tries multiple search domains and may print "can't find" for
+	// non-default domains even when the FQDN resolves successfully. So check
+	// that the output contains a successful "Address" line for our service
+	// (which means the FQDN resolved) rather than checking for absence of errors.
+	outStr := string(out)
+	lines := strings.Split(outStr, "\n")
+	resolved := false
+	for i, line := range lines {
+		// nslookup output: the first "Address:" line is the DNS server itself.
+		// Subsequent "Address:" lines are the resolution results.
+		if strings.Contains(line, "Name:") && strings.Contains(line, serverName) {
+			// The line after "Name:" should have "Address:" with the pod IP.
+			if i+1 < len(lines) && strings.Contains(lines[i+1], "Address:") {
+				resolved = true
+			}
+		}
+	}
+	if !resolved {
+		t.Errorf("DNS resolution failed for %q: %s", serverName, outStr)
 	}
 }
 


### PR DESCRIPTION
Adds network CRUD endpoints (create, inspect, list, delete, prune),
connect/disconnect, container-to-container DNS via headless Services,
network aliases, port mapping via ClusterIP Services, and service
cleanup on container deletion. Includes unit tests and integration tests.

https://claude.ai/code/session_01Vg6fHyHKd6zt75JhmBFhnv