### PR TITLE
Implement docker cp via exec tar in main container

### DIFF
--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -192,12 +192,20 @@ func (s *Server) ensureCpHelper(ctx context.Context, podName string) (string, er
 
 	// Create a new helper. The command writes its PID to a file then
 	// replaces the shell with sleep so the PID stays the same.
+	// The helper must run as root with SYS_PTRACE to access /proc/1/root.
 	helperName := "cp-" + uuid.New().String()[:8]
+	rootUser := int64(0)
 	ec := corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:    helperName,
 			Image:   cpHelperImage,
 			Command: []string{"sh", "-c", "echo $$ > /tmp/.cp-pid && exec sleep " + cpHelperTimeout},
+			SecurityContext: &corev1.SecurityContext{
+				RunAsUser: &rootUser,
+				Capabilities: &corev1.Capabilities{
+					Add: []corev1.Capability{"SYS_PTRACE"},
+				},
+			},
 		},
 		TargetContainerName: "main",
 	}
@@ -291,8 +299,9 @@ func (s *Server) execInHelper(ctx context.Context, podName, helperName string, c
 		return err
 	}
 
+	var stderrBuf bytes.Buffer
 	opts := remotecommand.StreamOptions{
-		Stderr: io.Discard,
+		Stderr: &stderrBuf,
 	}
 	if stdin != nil {
 		opts.Stdin = stdin
@@ -303,7 +312,13 @@ func (s *Server) execInHelper(ctx context.Context, podName, helperName string, c
 		opts.Stdout = io.Discard
 	}
 
-	return executor.StreamWithContext(ctx, opts)
+	if err := executor.StreamWithContext(ctx, opts); err != nil {
+		if stderrBuf.Len() > 0 {
+			return fmt.Errorf("%w: %s", err, strings.TrimSpace(stderrBuf.String()))
+		}
+		return err
+	}
+	return nil
 }
 
 // execStat runs stat in the helper container and returns path metadata.

--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -24,12 +24,18 @@ import (
 
 const (
 	// cpHelperImage is the Chainguard image used for ephemeral cp-helper containers.
-	// It contains tar and basic utilities needed for archive operations.
+	// It provides tar, stat, and sh — everything needed for archive operations.
 	cpHelperImage = "cgr.dev/chainguard/busybox:latest"
 
 	// mainContainerRoot is the path to the main container's root filesystem
-	// as seen from the ephemeral container via shared PID namespace.
+	// as seen from the ephemeral container via the shared PID namespace
+	// (provided by targetContainerName). PID 1 is the main container's process.
 	mainContainerRoot = "/proc/1/root"
+
+	// cpHelperTimeout is the maximum seconds a cp-helper stays alive.
+	// The helper is terminated immediately after use; this timeout is a
+	// safety net in case the cleanup signal fails.
+	cpHelperTimeout = "300"
 )
 
 // containerPathStat holds stat info for archive HEAD/GET responses.
@@ -42,8 +48,10 @@ type containerPathStat struct {
 	LinkTarget string      `json:"linkTarget"`
 }
 
-// archiveGet handles GET /containers/{name}/archive?path=<path>
-// Returns a tar archive of the file or directory at the given path.
+// --- Archive endpoints ---
+
+// archiveGet handles GET /containers/{name}/archive?path=<path>.
+// Returns a tar archive of the resource at the given path.
 func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
@@ -56,16 +64,16 @@ func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info("archive get")
 
-	// Ensure the ephemeral helper container exists and is running.
 	helperName, err := s.ensureCpHelper(ctx, name)
 	if err != nil {
 		log.Errorf("failed to ensure cp-helper: %v", err)
 		writeError(w, err)
 		return
 	}
+	defer s.cleanupCpHelper(name, helperName)
 
-	// First, stat the path to get metadata for the header.
-	stat, err := s.statInHelper(ctx, name, helperName, archivePath)
+	// Stat the path for the response header.
+	stat, err := s.execStat(ctx, name, helperName, archivePath)
 	if err != nil {
 		log.Errorf("stat failed: %v", err)
 		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
@@ -73,9 +81,7 @@ func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	statJSON, _ := json.Marshal(stat)
-	statEncoded := base64.StdEncoding.EncodeToString(statJSON)
-
-	w.Header().Set("X-Docker-Container-Path-Stat", statEncoded)
+	w.Header().Set("X-Docker-Container-Path-Stat", base64.StdEncoding.EncodeToString(statJSON))
 	w.Header().Set("Content-Type", "application/x-tar")
 	w.WriteHeader(http.StatusOK)
 
@@ -84,34 +90,15 @@ func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	parent := path.Dir(targetPath)
 	base := path.Base(targetPath)
 
-	execOpt := &corev1.PodExecOptions{
-		Container: helperName,
-		Command:   []string{"tar", "cf", "-", "-C", parent, base},
-		Stdout:    true,
-		Stderr:    true,
-	}
-
-	req := s.clientset.CoreV1().RESTClient().Post().
-		Resource("pods").Name(name).Namespace("default").
-		SubResource("exec")
-	req.VersionedParams(execOpt, scheme.ParameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
-	if err != nil {
-		log.Errorf("exec error: %v", err)
-		return
-	}
-
-	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdout: w,
-		Stderr: io.Discard,
-	}); err != nil {
+	if err := s.execInHelper(ctx, name, helperName,
+		[]string{"tar", "cf", "-", "-C", parent, base},
+		nil, w); err != nil {
 		log.Errorf("tar stream error: %v", err)
 	}
 }
 
-// archivePut handles PUT /containers/{name}/archive?path=<path>
-// Extracts a tar archive from the request body into the container at the given path.
+// archivePut handles PUT /containers/{name}/archive?path=<path>.
+// Extracts a tar archive from the request body into the container.
 func (s *Server) archivePut(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
@@ -130,35 +117,14 @@ func (s *Server) archivePut(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	defer s.cleanupCpHelper(name, helperName)
 
 	// Extract the tar stream into the main container's filesystem.
 	targetPath := path.Join(mainContainerRoot, archivePath)
 
-	execOpt := &corev1.PodExecOptions{
-		Container: helperName,
-		Command:   []string{"tar", "xf", "-", "-C", targetPath},
-		Stdin:     true,
-		Stdout:    true,
-		Stderr:    true,
-	}
-
-	req := s.clientset.CoreV1().RESTClient().Post().
-		Resource("pods").Name(name).Namespace("default").
-		SubResource("exec")
-	req.VersionedParams(execOpt, scheme.ParameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
-	if err != nil {
-		log.Errorf("exec error: %v", err)
-		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
-		return
-	}
-
-	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdin:  r.Body,
-		Stdout: io.Discard,
-		Stderr: io.Discard,
-	}); err != nil {
+	if err := s.execInHelper(ctx, name, helperName,
+		[]string{"tar", "xf", "-", "-C", targetPath},
+		r.Body, io.Discard); err != nil {
 		log.Errorf("tar extract error: %v", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
 		return
@@ -167,8 +133,8 @@ func (s *Server) archivePut(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// archiveHead handles HEAD /containers/{name}/archive?path=<path>
-// Returns stat info about a path in the container via the X-Docker-Container-Path-Stat header.
+// archiveHead handles HEAD /containers/{name}/archive?path=<path>.
+// Returns stat info about a path via the X-Docker-Container-Path-Stat header.
 func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	name := r.PathValue("name")
@@ -187,8 +153,9 @@ func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
+	defer s.cleanupCpHelper(name, helperName)
 
-	stat, err := s.statInHelper(ctx, name, helperName, archivePath)
+	stat, err := s.execStat(ctx, name, helperName, archivePath)
 	if err != nil {
 		log.Errorf("stat failed: %v", err)
 		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
@@ -196,61 +163,71 @@ func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
 	}
 
 	statJSON, _ := json.Marshal(stat)
-	statEncoded := base64.StdEncoding.EncodeToString(statJSON)
-	w.Header().Set("X-Docker-Container-Path-Stat", statEncoded)
+	w.Header().Set("X-Docker-Container-Path-Stat", base64.StdEncoding.EncodeToString(statJSON))
 	w.WriteHeader(http.StatusOK)
 }
 
-// ensureCpHelper adds an ephemeral cp-helper container to the pod if one
-// isn't already running, then waits for it to be ready. Returns the name
-// of the running helper container.
+// --- Ephemeral container helpers ---
+
+// ensureCpHelper ensures a cp-helper ephemeral container is running on the pod.
+// If one already exists and is running, it's reused. Otherwise a new one is created.
+// The helper writes its PID to /tmp/.cp-pid so cleanupCpHelper can terminate it.
 func (s *Server) ensureCpHelper(ctx context.Context, podName string) (string, error) {
 	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
 
-	// Check if a cp-helper is already running.
+	// Reuse an already-running helper if one exists.
 	for _, ec := range pod.Spec.EphemeralContainers {
-		if strings.HasPrefix(ec.Name, "cp-") {
-			// Check if it's running.
-			for _, cs := range pod.Status.EphemeralContainerStatuses {
-				if cs.Name == ec.Name && cs.State.Running != nil {
-					return ec.Name, nil
-				}
+		if !strings.HasPrefix(ec.Name, "cp-") {
+			continue
+		}
+		for _, cs := range pod.Status.EphemeralContainerStatuses {
+			if cs.Name == ec.Name && cs.State.Running != nil {
+				return ec.Name, nil
 			}
 		}
 	}
 
-	// Add a new ephemeral container.
+	// Create a new helper. The command writes its PID to a file then
+	// replaces the shell with sleep so the PID stays the same.
 	helperName := "cp-" + uuid.New().String()[:8]
 	ec := corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:    helperName,
 			Image:   cpHelperImage,
-			Command: []string{"sleep", "3600"},
+			Command: []string{"sh", "-c", "echo $$ > /tmp/.cp-pid && exec sleep " + cpHelperTimeout},
 		},
 		TargetContainerName: "main",
 	}
 
 	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
-
-	_, err = s.clientset.CoreV1().Pods("default").UpdateEphemeralContainers(ctx, podName, pod, metav1.UpdateOptions{})
-	if err != nil {
-		return "", fmt.Errorf("failed to add ephemeral container: %w", err)
+	if _, err := s.clientset.CoreV1().Pods("default").UpdateEphemeralContainers(
+		ctx, podName, pod, metav1.UpdateOptions{}); err != nil {
+		return "", fmt.Errorf("failed to add cp-helper: %w", err)
 	}
 
-	// Wait for the ephemeral container to be running.
-	if err := s.waitForEphemeralContainer(ctx, podName, helperName); err != nil {
+	if err := s.waitForEphemeralRunning(ctx, podName, helperName); err != nil {
 		return "", err
 	}
 
 	return helperName, nil
 }
 
-// waitForEphemeralContainer watches the pod until the named ephemeral container is running.
-func (s *Server) waitForEphemeralContainer(ctx context.Context, podName, containerName string) error {
-	// First check current state.
+// cleanupCpHelper terminates the cp-helper by killing its sleep process
+// using the PID saved at startup. This is best-effort; the helper will
+// auto-terminate after cpHelperTimeout seconds regardless.
+func (s *Server) cleanupCpHelper(podName, helperName string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	_ = s.execInHelper(ctx, podName, helperName,
+		[]string{"sh", "-c", "kill $(cat /tmp/.cp-pid) 2>/dev/null; true"},
+		nil, io.Discard)
+}
+
+// waitForEphemeralRunning watches the pod until the named ephemeral container is running.
+func (s *Server) waitForEphemeralRunning(ctx context.Context, podName, containerName string) error {
 	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
 	if err != nil {
 		return err
@@ -281,7 +258,8 @@ func (s *Server) waitForEphemeralContainer(ctx context.Context, podName, contain
 					return nil
 				}
 				if cs.State.Terminated != nil {
-					return fmt.Errorf("ephemeral container %s terminated: %s", containerName, cs.State.Terminated.Reason)
+					return fmt.Errorf("ephemeral container %s terminated: %s",
+						containerName, cs.State.Terminated.Reason)
 				}
 			}
 		}
@@ -289,15 +267,16 @@ func (s *Server) waitForEphemeralContainer(ctx context.Context, podName, contain
 	return fmt.Errorf("watch closed before ephemeral container %s started", containerName)
 }
 
-// statInHelper runs stat in the cp-helper container and returns path metadata.
-func (s *Server) statInHelper(ctx context.Context, podName, helperName, archivePath string) (*containerPathStat, error) {
-	targetPath := path.Join(mainContainerRoot, archivePath)
+// --- Exec helpers ---
 
-	// Use stat to get file info. BusyBox stat output format:
-	// %n=name, %s=size, %f=mode(hex), %Y=mtime(epoch), %N=symlink target
+// execInHelper runs a command in the cp-helper container via exec.
+// If stdin is non-nil it is piped to the command. stdout receives the
+// command's standard output (pass io.Discard if unneeded).
+func (s *Server) execInHelper(ctx context.Context, podName, helperName string, cmd []string, stdin io.Reader, stdout io.Writer) error {
 	execOpt := &corev1.PodExecOptions{
 		Container: helperName,
-		Command:   []string{"stat", "-c", "%n\n%s\n%f\n%Y", targetPath},
+		Command:   cmd,
+		Stdin:     stdin != nil,
 		Stdout:    true,
 		Stderr:    true,
 	}
@@ -307,17 +286,36 @@ func (s *Server) statInHelper(ctx context.Context, podName, helperName, archiveP
 		SubResource("exec")
 	req.VersionedParams(execOpt, scheme.ParameterCodec)
 
-	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
+	executor, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	var stdout, stderr bytes.Buffer
-	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
-		Stdout: &stdout,
-		Stderr: &stderr,
-	}); err != nil {
-		return nil, fmt.Errorf("stat failed: %s: %w", stderr.String(), err)
+	opts := remotecommand.StreamOptions{
+		Stderr: io.Discard,
+	}
+	if stdin != nil {
+		opts.Stdin = stdin
+	}
+	if stdout != nil {
+		opts.Stdout = stdout
+	} else {
+		opts.Stdout = io.Discard
+	}
+
+	return executor.StreamWithContext(ctx, opts)
+}
+
+// execStat runs stat in the helper container and returns path metadata.
+func (s *Server) execStat(ctx context.Context, podName, helperName, archivePath string) (*containerPathStat, error) {
+	targetPath := path.Join(mainContainerRoot, archivePath)
+
+	// BusyBox stat format: %n=name, %s=size, %f=mode(hex), %Y=mtime(epoch)
+	var stdout bytes.Buffer
+	if err := s.execInHelper(ctx, podName, helperName,
+		[]string{"stat", "-c", "%n\n%s\n%f\n%Y", targetPath},
+		nil, &stdout); err != nil {
+		return nil, err
 	}
 
 	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")

--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -1,0 +1,338 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"github.com/google/uuid"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/remotecommand"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+const (
+	// cpHelperImage is the Chainguard image used for ephemeral cp-helper containers.
+	// It contains tar and basic utilities needed for archive operations.
+	cpHelperImage = "cgr.dev/chainguard/busybox:latest"
+
+	// mainContainerRoot is the path to the main container's root filesystem
+	// as seen from the ephemeral container via shared PID namespace.
+	mainContainerRoot = "/proc/1/root"
+)
+
+// containerPathStat holds stat info for archive HEAD/GET responses.
+// Matches the Docker API's X-Docker-Container-Path-Stat header format.
+type containerPathStat struct {
+	Name       string      `json:"name"`
+	Size       int64       `json:"size"`
+	Mode       os.FileMode `json:"mode"`
+	Mtime      time.Time   `json:"mtime"`
+	LinkTarget string      `json:"linkTarget"`
+}
+
+// archiveGet handles GET /containers/{name}/archive?path=<path>
+// Returns a tar archive of the file or directory at the given path.
+func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	archivePath := r.URL.Query().Get("path")
+	log := clog.FromContext(ctx).With("name", name, "path", archivePath)
+
+	if archivePath == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"missing required query parameter: path"})
+		return
+	}
+	log.Info("archive get")
+
+	// Ensure the ephemeral helper container exists and is running.
+	helperName, err := s.ensureCpHelper(ctx, name)
+	if err != nil {
+		log.Errorf("failed to ensure cp-helper: %v", err)
+		writeError(w, err)
+		return
+	}
+
+	// First, stat the path to get metadata for the header.
+	stat, err := s.statInHelper(ctx, name, helperName, archivePath)
+	if err != nil {
+		log.Errorf("stat failed: %v", err)
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
+		return
+	}
+
+	statJSON, _ := json.Marshal(stat)
+	statEncoded := base64.StdEncoding.EncodeToString(statJSON)
+
+	w.Header().Set("X-Docker-Container-Path-Stat", statEncoded)
+	w.Header().Set("Content-Type", "application/x-tar")
+	w.WriteHeader(http.StatusOK)
+
+	// Tar up the path from the main container's filesystem.
+	targetPath := path.Join(mainContainerRoot, archivePath)
+	parent := path.Dir(targetPath)
+	base := path.Base(targetPath)
+
+	execOpt := &corev1.PodExecOptions{
+		Container: helperName,
+		Command:   []string{"tar", "cf", "-", "-C", parent, base},
+		Stdout:    true,
+		Stderr:    true,
+	}
+
+	req := s.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Name(name).Namespace("default").
+		SubResource("exec")
+	req.VersionedParams(execOpt, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
+	if err != nil {
+		log.Errorf("exec error: %v", err)
+		return
+	}
+
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: w,
+		Stderr: io.Discard,
+	}); err != nil {
+		log.Errorf("tar stream error: %v", err)
+	}
+}
+
+// archivePut handles PUT /containers/{name}/archive?path=<path>
+// Extracts a tar archive from the request body into the container at the given path.
+func (s *Server) archivePut(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	archivePath := r.URL.Query().Get("path")
+	log := clog.FromContext(ctx).With("name", name, "path", archivePath)
+
+	if archivePath == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"missing required query parameter: path"})
+		return
+	}
+	log.Info("archive put")
+
+	helperName, err := s.ensureCpHelper(ctx, name)
+	if err != nil {
+		log.Errorf("failed to ensure cp-helper: %v", err)
+		writeError(w, err)
+		return
+	}
+
+	// Extract the tar stream into the main container's filesystem.
+	targetPath := path.Join(mainContainerRoot, archivePath)
+
+	execOpt := &corev1.PodExecOptions{
+		Container: helperName,
+		Command:   []string{"tar", "xf", "-", "-C", targetPath},
+		Stdin:     true,
+		Stdout:    true,
+		Stderr:    true,
+	}
+
+	req := s.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Name(name).Namespace("default").
+		SubResource("exec")
+	req.VersionedParams(execOpt, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
+	if err != nil {
+		log.Errorf("exec error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+		return
+	}
+
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdin:  r.Body,
+		Stdout: io.Discard,
+		Stderr: io.Discard,
+	}); err != nil {
+		log.Errorf("tar extract error: %v", err)
+		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// archiveHead handles HEAD /containers/{name}/archive?path=<path>
+// Returns stat info about a path in the container via the X-Docker-Container-Path-Stat header.
+func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	name := r.PathValue("name")
+	archivePath := r.URL.Query().Get("path")
+	log := clog.FromContext(ctx).With("name", name, "path", archivePath)
+
+	if archivePath == "" {
+		writeJSON(w, http.StatusBadRequest, errorResponse{"missing required query parameter: path"})
+		return
+	}
+	log.Info("archive head")
+
+	helperName, err := s.ensureCpHelper(ctx, name)
+	if err != nil {
+		log.Errorf("failed to ensure cp-helper: %v", err)
+		writeError(w, err)
+		return
+	}
+
+	stat, err := s.statInHelper(ctx, name, helperName, archivePath)
+	if err != nil {
+		log.Errorf("stat failed: %v", err)
+		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
+		return
+	}
+
+	statJSON, _ := json.Marshal(stat)
+	statEncoded := base64.StdEncoding.EncodeToString(statJSON)
+	w.Header().Set("X-Docker-Container-Path-Stat", statEncoded)
+	w.WriteHeader(http.StatusOK)
+}
+
+// ensureCpHelper adds an ephemeral cp-helper container to the pod if one
+// isn't already running, then waits for it to be ready. Returns the name
+// of the running helper container.
+func (s *Server) ensureCpHelper(ctx context.Context, podName string) (string, error) {
+	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// Check if a cp-helper is already running.
+	for _, ec := range pod.Spec.EphemeralContainers {
+		if strings.HasPrefix(ec.Name, "cp-") {
+			// Check if it's running.
+			for _, cs := range pod.Status.EphemeralContainerStatuses {
+				if cs.Name == ec.Name && cs.State.Running != nil {
+					return ec.Name, nil
+				}
+			}
+		}
+	}
+
+	// Add a new ephemeral container.
+	helperName := "cp-" + uuid.New().String()[:8]
+	ec := corev1.EphemeralContainer{
+		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+			Name:    helperName,
+			Image:   cpHelperImage,
+			Command: []string{"sleep", "3600"},
+		},
+		TargetContainerName: "main",
+	}
+
+	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
+
+	_, err = s.clientset.CoreV1().Pods("default").UpdateEphemeralContainers(ctx, podName, pod, metav1.UpdateOptions{})
+	if err != nil {
+		return "", fmt.Errorf("failed to add ephemeral container: %w", err)
+	}
+
+	// Wait for the ephemeral container to be running.
+	if err := s.waitForEphemeralContainer(ctx, podName, helperName); err != nil {
+		return "", err
+	}
+
+	return helperName, nil
+}
+
+// waitForEphemeralContainer watches the pod until the named ephemeral container is running.
+func (s *Server) waitForEphemeralContainer(ctx context.Context, podName, containerName string) error {
+	// First check current state.
+	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	for _, cs := range pod.Status.EphemeralContainerStatuses {
+		if cs.Name == containerName && cs.State.Running != nil {
+			return nil
+		}
+	}
+
+	watcher, err := s.clientset.CoreV1().Pods("default").Watch(ctx, metav1.ListOptions{
+		FieldSelector:   "metadata.name=" + podName,
+		ResourceVersion: pod.ResourceVersion,
+	})
+	if err != nil {
+		return err
+	}
+	defer watcher.Stop()
+
+	for event := range watcher.ResultChan() {
+		pod, ok := event.Object.(*corev1.Pod)
+		if !ok {
+			continue
+		}
+		for _, cs := range pod.Status.EphemeralContainerStatuses {
+			if cs.Name == containerName {
+				if cs.State.Running != nil {
+					return nil
+				}
+				if cs.State.Terminated != nil {
+					return fmt.Errorf("ephemeral container %s terminated: %s", containerName, cs.State.Terminated.Reason)
+				}
+			}
+		}
+	}
+	return fmt.Errorf("watch closed before ephemeral container %s started", containerName)
+}
+
+// statInHelper runs stat in the cp-helper container and returns path metadata.
+func (s *Server) statInHelper(ctx context.Context, podName, helperName, archivePath string) (*containerPathStat, error) {
+	targetPath := path.Join(mainContainerRoot, archivePath)
+
+	// Use stat to get file info. BusyBox stat output format:
+	// %n=name, %s=size, %f=mode(hex), %Y=mtime(epoch), %N=symlink target
+	execOpt := &corev1.PodExecOptions{
+		Container: helperName,
+		Command:   []string{"stat", "-c", "%n\n%s\n%f\n%Y", targetPath},
+		Stdout:    true,
+		Stderr:    true,
+	}
+
+	req := s.clientset.CoreV1().RESTClient().Post().
+		Resource("pods").Name(podName).Namespace("default").
+		SubResource("exec")
+	req.VersionedParams(execOpt, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(&s.restConfig, http.MethodPost, req.URL())
+	if err != nil {
+		return nil, err
+	}
+
+	var stdout, stderr bytes.Buffer
+	if err := exec.StreamWithContext(ctx, remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	}); err != nil {
+		return nil, fmt.Errorf("stat failed: %s: %w", stderr.String(), err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) < 4 {
+		return nil, fmt.Errorf("unexpected stat output: %s", stdout.String())
+	}
+
+	size, _ := strconv.ParseInt(lines[1], 10, 64)
+	modeHex, _ := strconv.ParseUint(lines[2], 16, 32)
+	mtimeEpoch, _ := strconv.ParseInt(lines[3], 10, 64)
+
+	return &containerPathStat{
+		Name:  path.Base(archivePath),
+		Size:  size,
+		Mode:  os.FileMode(modeHex),
+		Mtime: time.Unix(mtimeEpoch, 0),
+	}, nil
+}

--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"bytes"
-	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -15,27 +14,10 @@ import (
 	"time"
 
 	"github.com/chainguard-dev/clog"
-	"github.com/google/uuid"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/kubectl/pkg/scheme"
-)
-
-const (
-	// cpHelperImage is the Chainguard image used for ephemeral cp-helper containers.
-	// It provides tar, stat, and sh — everything needed for archive operations.
-	cpHelperImage = "cgr.dev/chainguard/busybox:latest"
-
-	// mainContainerRoot is the path to the main container's root filesystem
-	// as seen from the ephemeral container via the shared PID namespace
-	// (provided by targetContainerName). PID 1 is the main container's process.
-	mainContainerRoot = "/proc/1/root"
-
-	// cpHelperTimeout is the maximum seconds a cp-helper stays alive.
-	// The helper is terminated immediately after use; this timeout is a
-	// safety net in case the cleanup signal fails.
-	cpHelperTimeout = "300"
 )
 
 // containerPathStat holds stat info for archive HEAD/GET responses.
@@ -49,6 +31,12 @@ type containerPathStat struct {
 }
 
 // --- Archive endpoints ---
+//
+// These implement the Docker archive API by exec-ing tar/stat directly in
+// the main container, the same approach kubectl cp uses. This requires the
+// container image to include tar (busybox, alpine, most distros do).
+// No ephemeral containers or elevated privileges are needed, so this works
+// on restrictive clusters like GKE Autopilot.
 
 // archiveGet handles GET /containers/{name}/archive?path=<path>.
 // Returns a tar archive of the resource at the given path.
@@ -64,16 +52,13 @@ func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info("archive get")
 
-	helperName, err := s.ensureCpHelper(ctx, name)
-	if err != nil {
-		log.Errorf("failed to ensure cp-helper: %v", err)
+	if _, err := s.clientset.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{}); err != nil {
 		writeError(w, err)
 		return
 	}
-	defer s.cleanupCpHelper(name, helperName)
 
 	// Stat the path for the response header.
-	stat, err := s.execStat(ctx, name, helperName, archivePath)
+	stat, err := s.execStat(ctx, name, archivePath)
 	if err != nil {
 		log.Errorf("stat failed: %v", err)
 		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
@@ -85,12 +70,11 @@ func (s *Server) archiveGet(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/x-tar")
 	w.WriteHeader(http.StatusOK)
 
-	// Tar up the path from the main container's filesystem.
-	targetPath := path.Join(mainContainerRoot, archivePath)
-	parent := path.Dir(targetPath)
-	base := path.Base(targetPath)
+	// Tar up the path inside the container.
+	parent := path.Dir(archivePath)
+	base := path.Base(archivePath)
 
-	if err := s.execInHelper(ctx, name, helperName,
+	if err := s.execInContainer(ctx, name,
 		[]string{"tar", "cf", "-", "-C", parent, base},
 		nil, w); err != nil {
 		log.Errorf("tar stream error: %v", err)
@@ -111,19 +95,13 @@ func (s *Server) archivePut(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info("archive put")
 
-	helperName, err := s.ensureCpHelper(ctx, name)
-	if err != nil {
-		log.Errorf("failed to ensure cp-helper: %v", err)
+	if _, err := s.clientset.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{}); err != nil {
 		writeError(w, err)
 		return
 	}
-	defer s.cleanupCpHelper(name, helperName)
 
-	// Extract the tar stream into the main container's filesystem.
-	targetPath := path.Join(mainContainerRoot, archivePath)
-
-	if err := s.execInHelper(ctx, name, helperName,
-		[]string{"tar", "xf", "-", "-C", targetPath},
+	if err := s.execInContainer(ctx, name,
+		[]string{"tar", "xf", "-", "-C", archivePath},
 		r.Body, io.Discard); err != nil {
 		log.Errorf("tar extract error: %v", err)
 		writeJSON(w, http.StatusInternalServerError, errorResponse{err.Error()})
@@ -147,15 +125,12 @@ func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
 	}
 	log.Info("archive head")
 
-	helperName, err := s.ensureCpHelper(ctx, name)
-	if err != nil {
-		log.Errorf("failed to ensure cp-helper: %v", err)
+	if _, err := s.clientset.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{}); err != nil {
 		writeError(w, err)
 		return
 	}
-	defer s.cleanupCpHelper(name, helperName)
 
-	stat, err := s.execStat(ctx, name, helperName, archivePath)
+	stat, err := s.execStat(ctx, name, archivePath)
 	if err != nil {
 		log.Errorf("stat failed: %v", err)
 		writeJSON(w, http.StatusNotFound, errorResponse{fmt.Sprintf("path %q not found in container: %v", archivePath, err)})
@@ -167,122 +142,14 @@ func (s *Server) archiveHead(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 }
 
-// --- Ephemeral container helpers ---
-
-// ensureCpHelper ensures a cp-helper ephemeral container is running on the pod.
-// If one already exists and is running, it's reused. Otherwise a new one is created.
-// The helper writes its PID to /tmp/.cp-pid so cleanupCpHelper can terminate it.
-func (s *Server) ensureCpHelper(ctx context.Context, podName string) (string, error) {
-	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-
-	// Reuse an already-running helper if one exists.
-	for _, ec := range pod.Spec.EphemeralContainers {
-		if !strings.HasPrefix(ec.Name, "cp-") {
-			continue
-		}
-		for _, cs := range pod.Status.EphemeralContainerStatuses {
-			if cs.Name == ec.Name && cs.State.Running != nil {
-				return ec.Name, nil
-			}
-		}
-	}
-
-	// Create a new helper. The command writes its PID to a file then
-	// replaces the shell with sleep so the PID stays the same.
-	// The helper must run as root with SYS_PTRACE to access /proc/1/root.
-	helperName := "cp-" + uuid.New().String()[:8]
-	rootUser := int64(0)
-	ec := corev1.EphemeralContainer{
-		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
-			Name:    helperName,
-			Image:   cpHelperImage,
-			Command: []string{"sh", "-c", "echo $$ > /tmp/.cp-pid && exec sleep " + cpHelperTimeout},
-			SecurityContext: &corev1.SecurityContext{
-				RunAsUser: &rootUser,
-				Capabilities: &corev1.Capabilities{
-					Add: []corev1.Capability{"SYS_PTRACE"},
-				},
-			},
-		},
-		TargetContainerName: "main",
-	}
-
-	pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, ec)
-	if _, err := s.clientset.CoreV1().Pods("default").UpdateEphemeralContainers(
-		ctx, podName, pod, metav1.UpdateOptions{}); err != nil {
-		return "", fmt.Errorf("failed to add cp-helper: %w", err)
-	}
-
-	if err := s.waitForEphemeralRunning(ctx, podName, helperName); err != nil {
-		return "", err
-	}
-
-	return helperName, nil
-}
-
-// cleanupCpHelper terminates the cp-helper by killing its sleep process
-// using the PID saved at startup. This is best-effort; the helper will
-// auto-terminate after cpHelperTimeout seconds regardless.
-func (s *Server) cleanupCpHelper(podName, helperName string) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	_ = s.execInHelper(ctx, podName, helperName,
-		[]string{"sh", "-c", "kill $(cat /tmp/.cp-pid) 2>/dev/null; true"},
-		nil, io.Discard)
-}
-
-// waitForEphemeralRunning watches the pod until the named ephemeral container is running.
-func (s *Server) waitForEphemeralRunning(ctx context.Context, podName, containerName string) error {
-	pod, err := s.clientset.CoreV1().Pods("default").Get(ctx, podName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	for _, cs := range pod.Status.EphemeralContainerStatuses {
-		if cs.Name == containerName && cs.State.Running != nil {
-			return nil
-		}
-	}
-
-	watcher, err := s.clientset.CoreV1().Pods("default").Watch(ctx, metav1.ListOptions{
-		FieldSelector:   "metadata.name=" + podName,
-		ResourceVersion: pod.ResourceVersion,
-	})
-	if err != nil {
-		return err
-	}
-	defer watcher.Stop()
-
-	for event := range watcher.ResultChan() {
-		pod, ok := event.Object.(*corev1.Pod)
-		if !ok {
-			continue
-		}
-		for _, cs := range pod.Status.EphemeralContainerStatuses {
-			if cs.Name == containerName {
-				if cs.State.Running != nil {
-					return nil
-				}
-				if cs.State.Terminated != nil {
-					return fmt.Errorf("ephemeral container %s terminated: %s",
-						containerName, cs.State.Terminated.Reason)
-				}
-			}
-		}
-	}
-	return fmt.Errorf("watch closed before ephemeral container %s started", containerName)
-}
-
 // --- Exec helpers ---
 
-// execInHelper runs a command in the cp-helper container via exec.
+// execInContainer runs a command in the main container via Kubernetes exec.
 // If stdin is non-nil it is piped to the command. stdout receives the
 // command's standard output (pass io.Discard if unneeded).
-func (s *Server) execInHelper(ctx context.Context, podName, helperName string, cmd []string, stdin io.Reader, stdout io.Writer) error {
+func (s *Server) execInContainer(ctx context.Context, podName string, cmd []string, stdin io.Reader, stdout io.Writer) error {
 	execOpt := &corev1.PodExecOptions{
-		Container: helperName,
+		Container: "main",
 		Command:   cmd,
 		Stdin:     stdin != nil,
 		Stdout:    true,
@@ -301,14 +168,13 @@ func (s *Server) execInHelper(ctx context.Context, podName, helperName string, c
 
 	var stderrBuf bytes.Buffer
 	opts := remotecommand.StreamOptions{
+		Stdout: stdout,
 		Stderr: &stderrBuf,
 	}
 	if stdin != nil {
 		opts.Stdin = stdin
 	}
-	if stdout != nil {
-		opts.Stdout = stdout
-	} else {
+	if stdout == nil {
 		opts.Stdout = io.Discard
 	}
 
@@ -321,14 +187,12 @@ func (s *Server) execInHelper(ctx context.Context, podName, helperName string, c
 	return nil
 }
 
-// execStat runs stat in the helper container and returns path metadata.
-func (s *Server) execStat(ctx context.Context, podName, helperName, archivePath string) (*containerPathStat, error) {
-	targetPath := path.Join(mainContainerRoot, archivePath)
-
+// execStat runs stat in the container and returns path metadata.
+func (s *Server) execStat(ctx context.Context, podName, archivePath string) (*containerPathStat, error) {
 	// BusyBox stat format: %n=name, %s=size, %f=mode(hex), %Y=mtime(epoch)
 	var stdout bytes.Buffer
-	if err := s.execInHelper(ctx, podName, helperName,
-		[]string{"stat", "-c", "%n\n%s\n%f\n%Y", targetPath},
+	if err := s.execInContainer(ctx, podName,
+		[]string{"stat", "-c", "%n\n%s\n%f\n%Y", archivePath},
 		nil, &stdout); err != nil {
 		return nil, err
 	}

--- a/internal/server/archive.go
+++ b/internal/server/archive.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"

--- a/internal/server/archive_test.go
+++ b/internal/server/archive_test.go
@@ -3,7 +3,6 @@ package server
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
@@ -50,7 +49,6 @@ func TestArchiveHeadMissingPath(t *testing.T) {
 
 	resp := request(t, ts, "HEAD", "/containers/test-pod/archive?path=", "")
 	defer resp.Body.Close()
-	// HEAD with empty path should return 400.
 	if resp.StatusCode != 400 {
 		t.Errorf("got %d, want 400", resp.StatusCode)
 	}
@@ -87,29 +85,6 @@ func TestArchiveHeadContainerNotFound(t *testing.T) {
 	if resp.StatusCode != 404 {
 		t.Errorf("got %d, want 404", resp.StatusCode)
 	}
-}
-
-func TestContainerCreateSharesProcessNamespace(t *testing.T) {
-	ts := newTestServer()
-	defer ts.Close()
-
-	resp := request(t, ts, "POST", "/containers/create?name=ns-test",
-		`{"Image": "alpine"}`)
-	resp.Body.Close()
-	if resp.StatusCode != 201 {
-		t.Fatalf("create: got %d, want 201", resp.StatusCode)
-	}
-
-	// Inspect the pod and verify shareProcessNamespace is set.
-	resp = request(t, ts, "GET", "/containers/ns-test/json", "")
-	if resp.StatusCode != 200 {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("inspect: got %d: %s", resp.StatusCode, body)
-	}
-	resp.Body.Close()
-	// The inspect response doesn't expose shareProcessNamespace directly,
-	// but the pod was created successfully with the field set.
-	// This test validates the creation path doesn't break.
 }
 
 func TestContainerPathStatJSON(t *testing.T) {

--- a/internal/server/archive_test.go
+++ b/internal/server/archive_test.go
@@ -1,0 +1,138 @@
+package server
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestArchiveGetMissingPath(t *testing.T) {
+	ts := newTestServer(corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	})
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/containers/test-pod/archive", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestArchivePutMissingPath(t *testing.T) {
+	ts := newTestServer(corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	})
+	defer ts.Close()
+
+	resp := request(t, ts, "PUT", "/containers/test-pod/archive", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestArchiveHeadMissingPath(t *testing.T) {
+	ts := newTestServer(corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "main", Image: "alpine"}}},
+		Status:     corev1.PodStatus{Phase: corev1.PodRunning},
+	})
+	defer ts.Close()
+
+	resp := request(t, ts, "HEAD", "/containers/test-pod/archive?path=", "")
+	defer resp.Body.Close()
+	// HEAD with empty path should return 400.
+	if resp.StatusCode != 400 {
+		t.Errorf("got %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestArchiveGetContainerNotFound(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "GET", "/containers/nope/archive?path=/etc", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestArchivePutContainerNotFound(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "PUT", "/containers/nope/archive?path=/tmp", "some-data")
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestArchiveHeadContainerNotFound(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "HEAD", "/containers/nope/archive?path=/etc", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("got %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestContainerCreateSharesProcessNamespace(t *testing.T) {
+	ts := newTestServer()
+	defer ts.Close()
+
+	resp := request(t, ts, "POST", "/containers/create?name=ns-test",
+		`{"Image": "alpine"}`)
+	resp.Body.Close()
+	if resp.StatusCode != 201 {
+		t.Fatalf("create: got %d, want 201", resp.StatusCode)
+	}
+
+	// Inspect the pod and verify shareProcessNamespace is set.
+	resp = request(t, ts, "GET", "/containers/ns-test/json", "")
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("inspect: got %d: %s", resp.StatusCode, body)
+	}
+	resp.Body.Close()
+	// The inspect response doesn't expose shareProcessNamespace directly,
+	// but the pod was created successfully with the field set.
+	// This test validates the creation path doesn't break.
+}
+
+func TestContainerPathStatJSON(t *testing.T) {
+	stat := &containerPathStat{
+		Name: "test.txt",
+		Size: 42,
+		Mode: 0644,
+	}
+	data, err := json.Marshal(stat)
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded := base64.StdEncoding.EncodeToString(data)
+
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got containerPathStat
+	if err := json.Unmarshal(decoded, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Name != "test.txt" || got.Size != 42 || got.Mode != 0644 {
+		t.Errorf("round-trip failed: got %+v", got)
+	}
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"runtime"
 	"strings"
@@ -676,6 +677,11 @@ func (s *Server) execStart(w http.ResponseWriter, r *http.Request) {
 	log := clog.FromContext(ctx).With("exec", id, "container", ec.containerName)
 	log.Info("exec start")
 
+	// Drain request body before hijacking — unread data in the TCP receive
+	// buffer causes the kernel to send RST instead of FIN on close.
+	io.Copy(io.Discard, r.Body)
+	r.Body.Close()
+
 	hj, ok := w.(http.Hijacker)
 	if !ok {
 		writeJSON(w, http.StatusInternalServerError, errorResponse{"server does not support hijacking"})
@@ -734,6 +740,12 @@ func (s *Server) execStart(w http.ResponseWriter, r *http.Request) {
 		writeStdcopyFrame(bufrw, 2, []byte(fmt.Sprintf("exec stream error: %v\n", err)))
 	}
 	bufrw.Flush()
+
+	// Gracefully shut down the write side so the client sees EOF
+	// instead of connection reset.
+	if cw, ok := conn.(interface{ CloseWrite() error }); ok {
+		cw.CloseWrite()
+	}
 
 	// Mark as not running so execInspect can report completion.
 	// Don't delete — Docker CLI calls GET /exec/{id}/json after the stream ends.

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -716,9 +716,16 @@ func (s *Server) execStart(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	streamOpts := remotecommand.StreamOptions{
-		Stdout: bufrw,
-		Stderr: bufrw,
+	streamOpts := remotecommand.StreamOptions{}
+	if ec.tty {
+		// TTY mode: raw stream, no framing.
+		streamOpts.Stdout = bufrw
+		streamOpts.Stderr = bufrw
+		streamOpts.Tty = true
+	} else {
+		// Non-TTY: Docker CLI expects multiplexed stream frames.
+		streamOpts.Stdout = &stdcopyWriter{bufrw, 1}
+		streamOpts.Stderr = &stdcopyWriter{bufrw, 2}
 	}
 	if ec.attachStdin {
 		streamOpts.Stdin = conn

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -735,8 +735,10 @@ func (s *Server) execStart(w http.ResponseWriter, r *http.Request) {
 	}
 	bufrw.Flush()
 
+	// Mark as not running so execInspect can report completion.
+	// Don't delete — Docker CLI calls GET /exec/{id}/json after the stream ends.
 	s.mu.Lock()
-	delete(s.execs, id)
+	ec.running = false
 	s.mu.Unlock()
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -181,6 +181,18 @@ func writeStdcopyFrame(w io.Writer, streamType byte, data []byte) {
 	w.Write(data)
 }
 
+// stdcopyWriter wraps an io.Writer to add Docker multiplexed stream framing.
+// Each Write call is wrapped in a frame with the given stream type.
+type stdcopyWriter struct {
+	w          io.Writer
+	streamType byte
+}
+
+func (sw *stdcopyWriter) Write(p []byte) (int, error) {
+	writeStdcopyFrame(sw.w, sw.streamType, p)
+	return len(p), nil
+}
+
 func podExitCode(pod *corev1.Pod) int {
 	for _, cs := range pod.Status.ContainerStatuses {
 		if cs.Name == "main" && cs.State.Terminated != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -60,6 +60,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("POST /containers/{name}/attach", s.containerAttach)
 	mux.HandleFunc("POST /containers/{name}/resize", s.containerResize)
 	mux.HandleFunc("POST /containers/{name}/exec", s.execCreate)
+	mux.HandleFunc("GET /containers/{name}/archive", s.archiveGet)
+	mux.HandleFunc("PUT /containers/{name}/archive", s.archivePut)
+	mux.HandleFunc("HEAD /containers/{name}/archive", s.archiveHead)
 	mux.HandleFunc("DELETE /containers/{name}", s.containerRm)
 
 	// Exec

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -873,8 +873,8 @@ func TestDockerCpDirectoryRoundTrip(t *testing.T) {
 	}
 }
 
-func TestDockerCpNoResourceLeak(t *testing.T) {
-	name := "test-cp-leak-" + randomSuffix()
+func TestDockerCpContainerStillRunning(t *testing.T) {
+	name := "test-cp-ok-" + randomSuffix()
 
 	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
 	dockerRun(t, "start", name)
@@ -885,25 +885,10 @@ func TestDockerCpNoResourceLeak(t *testing.T) {
 	os.WriteFile(tmpFile, []byte("leak-test"), 0644)
 	dockerRun(t, "cp", tmpFile, name+":/tmp/test.txt")
 
-	// Wait for the cleanup to take effect.
-	time.Sleep(3 * time.Second)
-
 	// The main container should still be running (cp didn't break it).
 	out := dockerRun(t, "inspect", "--format", "{{.State.Running}}", name)
 	if !strings.Contains(out, "true") {
 		t.Errorf("container should still be running after cp, got: %s", out)
-	}
-
-	// Verify there are no running cp-helper processes left inside the container.
-	// In a shared PID namespace, the main container can see helper processes.
-	// With targetContainerName (no shareProcessNamespace), the main container's
-	// PID namespace is joined by the helper. After cleanup, the helper's sleep
-	// should be gone. We check by listing processes visible to the main container.
-	out = dockerRun(t, "exec", name, "sh", "-c", "ps aux 2>/dev/null || echo no-ps")
-	t.Logf("processes after cp: %s", out)
-	// ps might not be available in busybox, but if it is, verify no sleep 300 helper.
-	if strings.Contains(out, "sleep 300") {
-		t.Errorf("cp-helper sleep process still running after cleanup: %s", out)
 	}
 }
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -806,6 +806,9 @@ func TestDockerCpFileFromContainer(t *testing.T) {
 	dockerRun(t, "start", name)
 	defer dockerCmd("rm", "-f", name).Run()
 
+	// Wait for the container to be fully running before exec.
+	time.Sleep(2 * time.Second)
+
 	// Create a file inside the container.
 	dockerRun(t, "exec", name, "sh", "-c", "echo 'hello from container' > /tmp/output.txt")
 

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -775,6 +775,135 @@ func TestContainerPruneCleansUpFromNetwork(t *testing.T) {
 	}
 }
 
+// --- Docker cp tests ---
+
+func TestDockerCpFileToContainer(t *testing.T) {
+	name := "test-cp-to-" + randomSuffix()
+
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Create a local file and copy it into the container.
+	tmpFile := filepath.Join(t.TempDir(), "hello.txt")
+	if err := os.WriteFile(tmpFile, []byte("hello from cp\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dockerRun(t, "cp", tmpFile, name+":/tmp/hello.txt")
+
+	// Verify the file landed inside the container.
+	out := dockerRun(t, "exec", name, "cat", "/tmp/hello.txt")
+	if !strings.Contains(out, "hello from cp") {
+		t.Errorf("expected 'hello from cp' in output, got: %s", out)
+	}
+}
+
+func TestDockerCpFileFromContainer(t *testing.T) {
+	name := "test-cp-from-" + randomSuffix()
+
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Create a file inside the container.
+	dockerRun(t, "exec", name, "sh", "-c", "echo 'hello from container' > /tmp/output.txt")
+
+	// Copy it out.
+	outFile := filepath.Join(t.TempDir(), "output.txt")
+	dockerRun(t, "cp", name+":/tmp/output.txt", outFile)
+
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("failed to read copied file: %v", err)
+	}
+	if !strings.Contains(string(data), "hello from container") {
+		t.Errorf("expected 'hello from container', got: %s", data)
+	}
+}
+
+func TestDockerCpDirectoryRoundTrip(t *testing.T) {
+	name := "test-cp-dir-" + randomSuffix()
+
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Create a local directory with files.
+	srcDir := filepath.Join(t.TempDir(), "mydir")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	os.WriteFile(filepath.Join(srcDir, "a.txt"), []byte("file a"), 0644)
+	os.WriteFile(filepath.Join(srcDir, "b.txt"), []byte("file b"), 0644)
+
+	// Copy directory into the container.
+	dockerRun(t, "cp", srcDir, name+":/tmp/mydir")
+
+	// Verify both files exist.
+	out := dockerRun(t, "exec", name, "cat", "/tmp/mydir/a.txt")
+	if !strings.Contains(out, "file a") {
+		t.Errorf("expected 'file a', got: %s", out)
+	}
+	out = dockerRun(t, "exec", name, "cat", "/tmp/mydir/b.txt")
+	if !strings.Contains(out, "file b") {
+		t.Errorf("expected 'file b', got: %s", out)
+	}
+
+	// Copy directory back out and verify.
+	outDir := filepath.Join(t.TempDir(), "out")
+	dockerRun(t, "cp", name+":/tmp/mydir", outDir)
+
+	data, err := os.ReadFile(filepath.Join(outDir, "a.txt"))
+	if err != nil {
+		t.Fatalf("failed to read a.txt: %v", err)
+	}
+	if !strings.Contains(string(data), "file a") {
+		t.Errorf("expected 'file a', got: %s", data)
+	}
+	data, err = os.ReadFile(filepath.Join(outDir, "b.txt"))
+	if err != nil {
+		t.Fatalf("failed to read b.txt: %v", err)
+	}
+	if !strings.Contains(string(data), "file b") {
+		t.Errorf("expected 'file b', got: %s", data)
+	}
+}
+
+func TestDockerCpNoResourceLeak(t *testing.T) {
+	name := "test-cp-leak-" + randomSuffix()
+
+	dockerRun(t, "create", "--name", name, "busybox", "sleep", "300")
+	dockerRun(t, "start", name)
+	defer dockerCmd("rm", "-f", name).Run()
+
+	// Perform a cp operation.
+	tmpFile := filepath.Join(t.TempDir(), "test.txt")
+	os.WriteFile(tmpFile, []byte("leak-test"), 0644)
+	dockerRun(t, "cp", tmpFile, name+":/tmp/test.txt")
+
+	// Wait for the cleanup to take effect.
+	time.Sleep(3 * time.Second)
+
+	// The main container should still be running (cp didn't break it).
+	out := dockerRun(t, "inspect", "--format", "{{.State.Running}}", name)
+	if !strings.Contains(out, "true") {
+		t.Errorf("container should still be running after cp, got: %s", out)
+	}
+
+	// Verify there are no running cp-helper processes left inside the container.
+	// In a shared PID namespace, the main container can see helper processes.
+	// With targetContainerName (no shareProcessNamespace), the main container's
+	// PID namespace is joined by the helper. After cleanup, the helper's sleep
+	// should be gone. We check by listing processes visible to the main container.
+	out = dockerRun(t, "exec", name, "sh", "-c", "ps aux 2>/dev/null || echo no-ps")
+	t.Logf("processes after cp: %s", out)
+	// ps might not be available in busybox, but if it is, verify no sleep 300 helper.
+	if strings.Contains(out, "sleep 300") {
+		t.Errorf("cp-helper sleep process still running after cleanup: %s", out)
+	}
+}
+
 // randomSuffix returns a short suffix for unique container names.
 func randomSuffix() string {
 	return fmt.Sprintf("%d", time.Now().UnixNano()%100000)

--- a/volumes-plan.md
+++ b/volumes-plan.md
@@ -82,4 +82,4 @@ Return `Mounts` in the inspect response, derived from the pod's volume mounts.
 - PVC resize not supported (would require StorageClass with `allowVolumeExpansion`)
 - `ReadWriteMany` not supported (would need a different StorageClass like Filestore)
 - Volume driver plugins not supported
-- No `docker cp` (would need exec + tar, possible but separate work)
+- `docker cp` implemented via ephemeral containers with `cgr.dev/chainguard/busybox:latest` (see `archive.go`)

--- a/volumes-plan.md
+++ b/volumes-plan.md
@@ -82,4 +82,4 @@ Return `Mounts` in the inspect response, derived from the pod's volume mounts.
 - PVC resize not supported (would require StorageClass with `allowVolumeExpansion`)
 - `ReadWriteMany` not supported (would need a different StorageClass like Filestore)
 - Volume driver plugins not supported
-- `docker cp` implemented via ephemeral containers with `cgr.dev/chainguard/busybox:latest` (see `archive.go`)
+- `docker cp` implemented via exec tar in the main container, like `kubectl cp` (see `archive.go`)


### PR DESCRIPTION
Implement `docker cp` by exec-ing `tar` and `stat` directly in the main
container — the same approach `kubectl cp` uses. This works on
unprivileged clusters like GKE Autopilot with no elevated permissions.

## Changes

- Add `GET`/`PUT`/`HEAD` `/containers/{name}/archive` endpoints implementing
  Docker's archive API
- `GET` (copy from container): exec `tar cf` in the container, stream to client
- `PUT` (copy to container): pipe request body into `tar xf` in the container
- `HEAD` (stat): exec `stat` to return path metadata via `X-Docker-Container-Path-Stat` header
- Integration tests for file cp to/from container and directory round-trips

## Design

Unlike the initial approach using ephemeral containers with `/proc/1/root`,
this uses direct exec into the main container. The ephemeral container
approach required `SYS_PTRACE` and root, which GKE Autopilot blocks.

The only requirement is that the container image includes `tar` and `stat`
(busybox, alpine, and most distros do). This is the same limitation as
`kubectl cp`.

https://claude.ai/code/session_01331gigiYTmvj5rX64Xk1uf